### PR TITLE
Fix DbContext concurrency error in PolicyForm

### DIFF
--- a/src/IAMS.Web/Components/Pages/Policies/PolicyForm.razor
+++ b/src/IAMS.Web/Components/Pages/Policies/PolicyForm.razor
@@ -481,13 +481,9 @@
         loading = true;
         try
         {
-            var tasks = new List<Task>
-            {
-                LoadInsuranceCompanies(),
-                LoadPolicyTypes()
-            };
-
-            await Task.WhenAll(tasks);
+            // Run sequentially to avoid DbContext concurrency issues
+            await LoadInsuranceCompanies();
+            await LoadPolicyTypes();
         }
         finally
         {


### PR DESCRIPTION
Changed LoadLookupData to run database queries sequentially instead of in parallel to avoid DbContext threading issues.

Error Fixed:
"A second operation was started on this context instance before a previous operation completed. This is usually caused by different threads concurrently using the same instance of DbContext."

Root Cause:
The LoadLookupData method was using Task.WhenAll to run LoadInsuranceCompanies() and LoadPolicyTypes() in parallel. Both methods call services that share the same DbContext instance through dependency injection, which is not thread-safe.

Solution:
Changed from parallel execution (Task.WhenAll) to sequential execution (await). While this is slightly slower, it ensures DbContext is only accessed by one operation at a time, preventing concurrency conflicts.

Alternative solutions would require either:
- Creating separate DbContext scopes for each parallel operation
- Implementing proper async/await patterns in the repository layer
- Using IDbContextFactory for parallel operations

The sequential approach is the safest and simplest fix for this issue.