### PR TITLE
Fix CurrencyExchangeRate cascade delete conflict in ApplicationDbContext

### DIFF
--- a/src/IAMS.Persistence/Contexts/ApplicationDbContext.cs
+++ b/src/IAMS.Persistence/Contexts/ApplicationDbContext.cs
@@ -161,6 +161,20 @@ namespace IAMS.Persistence.Contexts
                 .WithMany(c => c.PolicyPayments)
                 .OnDelete(DeleteBehavior.Restrict);
 
+            // Configure CurrencyExchangeRate to prevent multiple cascade paths
+            // SQL Server doesn't allow cascade delete on both FK relationships to the same table
+            modelBuilder.Entity<CurrencyExchangeRate>()
+                .HasOne(e => e.FromCurrency)
+                .WithMany()
+                .HasForeignKey(e => e.FromCurrencyId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<CurrencyExchangeRate>()
+                .HasOne(e => e.ToCurrency)
+                .WithMany()
+                .HasForeignKey(e => e.ToCurrencyId)
+                .OnDelete(DeleteBehavior.Restrict);
+
             ParametricDataSeeder.SeedParametricData(modelBuilder);
 
         }


### PR DESCRIPTION
SQL Server error: "Introducing FOREIGN KEY constraint 'FK_CurrencyExchangeRates_Currencies_ToCurrencyId' on table 'CurrencyExchangeRates' may cause cycles or multiple cascade paths."

Root cause:
The CurrencyExchangeRate entity has two foreign keys pointing to the same Currency table:
- FromCurrencyId -> FromCurrency
- ToCurrencyId -> ToCurrency

By default, EF Core sets DeleteBehavior.Cascade on both relationships, but SQL Server doesn't allow this because deleting a Currency would create ambiguous cascade paths.

Solution:
Explicitly configured both relationships with DeleteBehavior.Restrict to prevent cascade deletes. This means:
- Deleting a Currency that is referenced in exchange rates will be blocked
- Exchange rates must be manually deleted first before deleting a Currency
- This is the correct behavior for financial data integrity

Similar pattern already used for other entities:
- Vehicle -> Brand, Model, Customer (Restrict)
- VehicleModel -> Brand (Restrict)
- PolicyPayment -> Currency (Restrict)