### PR TITLE
Implement all unimplemented repository and service methods

### DIFF
--- a/src/IAMS.Application/Interfaces/Repositories/IPolicyClaimRepository.cs
+++ b/src/IAMS.Application/Interfaces/Repositories/IPolicyClaimRepository.cs
@@ -1,6 +1,5 @@
 ﻿using IAMS.Domain.Entities;
 using IAMS.Domain.Enums;
-using System.Security.Claims;
 
 namespace IAMS.Application.Interfaces.Repositories
 {
@@ -12,7 +11,7 @@ namespace IAMS.Application.Interfaces.Repositories
         Task<IEnumerable<PolicyClaim>> GetClaimsByDateRangeAsync(DateTime fromDate, DateTime toDate);
         Task<decimal> GetTotalClaimAmountByPolicyIdAsync(int policyId);
         Task<DateTime?> GetLastClaimDateAsync(int customerId);
-        Task<List<Claim>> GetClaimsByCustomerIdAsync(int customerId);
+        Task<List<PolicyClaim>> GetClaimsByCustomerIdAsync(int customerId);
         Task<int> GetClaimCountByStatusAsync(ClaimStatus status);
         Task<decimal> GetTotalClaimAmountAsync(DateTime? startDate = null, DateTime? endDate = null);
     }

--- a/src/IAMS.Domain/Events/CustomerDeletedEvent.cs
+++ b/src/IAMS.Domain/Events/CustomerDeletedEvent.cs
@@ -13,12 +13,13 @@ namespace IAMS.Domain.Events
         public Customer Customer { get; }
         public string DeletedBy { get; }
 
-        public DateTime OccurredOn => throw new NotImplementedException();
+        public DateTime OccurredOn { get; }
 
         public CustomerDeletedEvent(Customer customer, string deletedBy)
         {
             Customer = customer;
             DeletedBy = deletedBy;
+            OccurredOn = DateTime.UtcNow;
         }
     }
 }

--- a/src/IAMS.Domain/Events/CustomerRestoredEvent.cs
+++ b/src/IAMS.Domain/Events/CustomerRestoredEvent.cs
@@ -13,12 +13,13 @@ namespace IAMS.Domain.Events
         public Customer Customer { get; }
         public string RestoredBy { get; }
 
-        public DateTime OccurredOn => throw new NotImplementedException();
+        public DateTime OccurredOn { get; }
 
         public CustomerRestoredEvent(Customer customer, string restoredBy)
         {
             Customer = customer;
             RestoredBy = restoredBy;
+            OccurredOn = DateTime.UtcNow;
         }
     }
 }

--- a/src/IAMS.Domain/Events/CustomerStatusChangedEvent.cs
+++ b/src/IAMS.Domain/Events/CustomerStatusChangedEvent.cs
@@ -16,7 +16,7 @@ namespace IAMS.Domain.Events
         public CustomerStatus NewStatus { get; }
         public string ChangedBy { get; }
 
-        public DateTime OccurredOn => throw new NotImplementedException();
+        public DateTime OccurredOn { get; }
 
         public CustomerStatusChangedEvent(Customer customer, CustomerStatus oldStatus, CustomerStatus newStatus, string changedBy)
         {
@@ -24,6 +24,7 @@ namespace IAMS.Domain.Events
             OldStatus = oldStatus;
             NewStatus = newStatus;
             ChangedBy = changedBy;
+            OccurredOn = DateTime.UtcNow;
         }
     }
 }

--- a/src/IAMS.Infrastructure/Services/ModuleService.cs
+++ b/src/IAMS.Infrastructure/Services/ModuleService.cs
@@ -105,16 +105,14 @@ namespace IAMS.Infrastructure.Services
                 _moduleCache[moduleName.ToLower()] = defaultValue;
             }
         }
-        // unimplemented
         public IEnumerable<string> GetEnabledModules()
         {
-            throw new NotImplementedException();
+            return _moduleCache.Where(kvp => kvp.Value).Select(kvp => kvp.Key);
         }
-
 
         public Task<Dictionary<string, bool>> GetAllModulesStatusAsync()
         {
-            throw new NotImplementedException();
+            return Task.FromResult(new Dictionary<string, bool>(_moduleCache));
         }
 
         Task IModuleService.EnableModuleAsync(string moduleName)

--- a/src/IAMS.Persistence/Repositories/CustomerRepository.cs
+++ b/src/IAMS.Persistence/Repositories/CustomerRepository.cs
@@ -442,9 +442,11 @@ namespace IAMS.Persistence.Repositories
             }
         }
 
-        public Task<int> GetNewCustomersCountAsync(DateTime fromDate)
+        public async Task<int> GetNewCustomersCountAsync(DateTime fromDate)
         {
-            throw new NotImplementedException();
+            return await _dbSet
+                .Where(c => !c.IsDeleted && c.CreatedOn >= fromDate)
+                .CountAsync();
         }
 
         #region private methods

--- a/src/IAMS.Persistence/Repositories/PolicyClaimRepository.cs
+++ b/src/IAMS.Persistence/Repositories/PolicyClaimRepository.cs
@@ -71,24 +71,46 @@ namespace IAMS.Persistence.Repositories
                 .FirstOrDefaultAsync();
         }
 
-        public Task<bool> ExistsByPolicyIdAsync(int policyId)
+        public async Task<bool> ExistsByPolicyIdAsync(int policyId)
         {
-            throw new NotImplementedException();
+            return await _dbSet
+                .AnyAsync(pc => pc.PolicyId == policyId && !pc.IsDeleted);
         }
 
-        public Task<List<Claim>> GetClaimsByCustomerIdAsync(int customerId)
+        public async Task<List<PolicyClaim>> GetClaimsByCustomerIdAsync(int customerId)
         {
-            throw new NotImplementedException();
+            return await _dbSet
+                .Include(pc => pc.Policy)
+                    .ThenInclude(p => p.Customer)
+                .Include(pc => pc.Policy)
+                    .ThenInclude(p => p.InsuranceCompany)
+                .Where(pc => !pc.IsDeleted && pc.Policy.CustomerId == customerId)
+                .OrderByDescending(pc => pc.ClaimDate)
+                .ToListAsync();
         }
 
-        public Task<int> GetClaimCountByStatusAsync(ClaimStatus status)
+        public async Task<int> GetClaimCountByStatusAsync(ClaimStatus status)
         {
-            throw new NotImplementedException();
+            return await _dbSet
+                .Where(pc => pc.Status == status && !pc.IsDeleted)
+                .CountAsync();
         }
 
-        public Task<decimal> GetTotalClaimAmountAsync(DateTime? startDate = null, DateTime? endDate = null)
+        public async Task<decimal> GetTotalClaimAmountAsync(DateTime? startDate = null, DateTime? endDate = null)
         {
-            throw new NotImplementedException();
+            var query = _dbSet.Where(pc => !pc.IsDeleted);
+
+            if (startDate.HasValue)
+            {
+                query = query.Where(pc => pc.ClaimDate >= startDate.Value);
+            }
+
+            if (endDate.HasValue)
+            {
+                query = query.Where(pc => pc.ClaimDate <= endDate.Value);
+            }
+
+            return await query.SumAsync(pc => pc.ClaimAmount);
         }
     }
 }

--- a/src/IAMS.Persistence/Repositories/PolicyRepository.cs
+++ b/src/IAMS.Persistence/Repositories/PolicyRepository.cs
@@ -456,7 +456,14 @@ namespace IAMS.Persistence.Repositories
 
         public async Task<List<Policy>> GetByVehicleIdAsync(int id)
         {
-            throw new NotImplementedException();
+            return await _dbSet
+                .Include(p => p.Customer)
+                .Include(p => p.InsuranceCompany)
+                .Include(p => p.PolicyType)
+                .Include(p => p.Vehicle)
+                .Where(p => p.VehicleId == id && !p.IsDeleted)
+                .OrderByDescending(p => p.CreatedOn)
+                .ToListAsync();
         }
     }
 }


### PR DESCRIPTION
This commit fills in 10 NotImplementedException placeholders with working implementations:

Domain Events (3 implementations):
- CustomerStatusChangedEvent.OccurredOn: Capture timestamp at event creation
- CustomerRestoredEvent.OccurredOn: Capture timestamp at event creation
- CustomerDeletedEvent.OccurredOn: Capture timestamp at event creation

Repository Methods (6 implementations):
- CustomerRepository.GetNewCustomersCountAsync: Count customers created since specified date
- PolicyClaimRepository.ExistsByPolicyIdAsync: Check if claims exist for a policy
- PolicyClaimRepository.GetClaimsByCustomerIdAsync: Get all claims for a customer through Policy navigation
- PolicyClaimRepository.GetClaimCountByStatusAsync: Count claims by status
- PolicyClaimRepository.GetTotalClaimAmountAsync: Sum claim amounts with optional date range filtering
- PolicyRepository.GetByVehicleIdAsync: Get all policies for a specific vehicle

Service Methods (2 implementations):
- ModuleService.GetEnabledModules: Return list of enabled module names (sync version)
- ModuleService.GetAllModulesStatusAsync: Return dictionary of all modules and their enabled status

Bug Fixes:
- IPolicyClaimRepository: Fixed return type from List<Claim> to List<PolicyClaim> and removed incorrect System.Security.Claims import

Note: AzureBlobStorageService methods (7) remain unimplemented as placeholders requiring Azure.Storage.Blobs package