### PR TITLE
Add Currency seeding to ParametricDataSeeder

### DIFF
--- a/src/IAMS.Persistence/Seeders/ParametricDataSeeder.cs
+++ b/src/IAMS.Persistence/Seeders/ParametricDataSeeder.cs
@@ -27,6 +27,9 @@ namespace IAMS.Persistence.Data
             // Seed Policy Types
             SeedPolicyTypes(modelBuilder, seedDate);
 
+            // Seed Currencies
+            SeedCurrencies(modelBuilder, seedDate);
+
             // Additional subdistricts and villages can be added as needed
         }
 
@@ -534,6 +537,68 @@ namespace IAMS.Persistence.Data
                     MinimumTermMonths = 12,
                     MaximumTermMonths = 12,
                     MinimumPremium = 200,
+                    CreatedOn = seedDate,
+                    CreatedBy = "System"
+                }
+            );
+        }
+
+        private static void SeedCurrencies(ModelBuilder modelBuilder, DateTime seedDate)
+        {
+            modelBuilder.Entity<Currency>().HasData(
+                new Currency
+                {
+                    Id = 1,
+                    Code = "TRY",
+                    Symbol = "₺",
+                    Name = "Turkish Lira",
+                    NameTr = "Türk Lirası",
+                    DecimalPlaces = 2,
+                    IsActive = true,
+                    IsBaseCurrency = true,
+                    DisplayOrder = 1,
+                    CreatedOn = seedDate,
+                    CreatedBy = "System"
+                },
+                new Currency
+                {
+                    Id = 2,
+                    Code = "USD",
+                    Symbol = "$",
+                    Name = "US Dollar",
+                    NameTr = "Amerikan Doları",
+                    DecimalPlaces = 2,
+                    IsActive = true,
+                    IsBaseCurrency = false,
+                    DisplayOrder = 2,
+                    CreatedOn = seedDate,
+                    CreatedBy = "System"
+                },
+                new Currency
+                {
+                    Id = 3,
+                    Code = "EUR",
+                    Symbol = "€",
+                    Name = "Euro",
+                    NameTr = "Euro",
+                    DecimalPlaces = 2,
+                    IsActive = true,
+                    IsBaseCurrency = false,
+                    DisplayOrder = 3,
+                    CreatedOn = seedDate,
+                    CreatedBy = "System"
+                },
+                new Currency
+                {
+                    Id = 4,
+                    Code = "GBP",
+                    Symbol = "£",
+                    Name = "British Pound",
+                    NameTr = "İngiliz Sterlini",
+                    DecimalPlaces = 2,
+                    IsActive = true,
+                    IsBaseCurrency = false,
+                    DisplayOrder = 4,
                     CreatedOn = seedDate,
                     CreatedBy = "System"
                 }


### PR DESCRIPTION
Added SeedCurrencies method to seed the Currencies table with default currencies needed by the system.

Currencies added:
1. TRY (Türk Lirası) - Turkish Lira - Base currency (₺)
2. USD (Amerikan Doları) - US Dollar ($)
3. EUR (Euro) - Euro (€)
4. GBP (İngiliz Sterlini) - British Pound (£)

This fixes the "Default currency (TRY) not found in system" error that was preventing vehicle creation.

Next step: Run a migration to apply this seed data to the database:
- dotnet ef migrations add SeedCurrencies -p src/IAMS.Persistence
- dotnet ef database update -p src/IAMS.Persistence