### PR TITLE
Fix customer report not updating when currency is changed

### DIFF
--- a/src/IAMS.Web/Components/Pages/Reports/CustomerReport.razor
+++ b/src/IAMS.Web/Components/Pages/Reports/CustomerReport.razor
@@ -360,7 +360,12 @@
                 _selectedCurrencyCode = value;
                 if (selectedCustomer != null)
                 {
-                    _ = LoadCustomerReport();
+                    // Recalculate statistics with new currency
+                    InvokeAsync(async () =>
+                    {
+                        await CalculateStatistics();
+                        StateHasChanged();
+                    });
                 }
             }
         }
@@ -418,6 +423,8 @@
         if (selectedCustomer == null) return;
 
         loading = true;
+        StateHasChanged(); // Update UI to show loading state
+
         try
         {
             // Load customer policies
@@ -448,6 +455,7 @@
         finally
         {
             loading = false;
+            StateHasChanged(); // Update UI after loading completes
         }
     }
 


### PR DESCRIPTION
The customer report was not properly refreshing when the currency selection changed. This was due to the async LoadCustomerReport() being called in a fire-and-forget pattern without proper UI state updates.

Changes:
- Modified selectedCurrencyCode setter to use InvokeAsync and call CalculateStatistics() directly instead of reloading all data
- Added StateHasChanged() calls after currency change to trigger UI re-render
- Added StateHasChanged() calls in LoadCustomerReport() to show loading state and update UI after data loads
- Improved responsiveness by only recalculating statistics instead of reloading policies when currency changes

The report now properly updates all financial figures (Total Premium, Total Commission, and Policy Type Breakdown) when the currency is changed in the dropdown.