### PR TITLE
Fix MudSelect type mismatch in PoliciesList by casting policyType.Id …

### DIFF
--- a/src/IAMS.Web/Components/Pages/Policies/PoliciesList.razor
+++ b/src/IAMS.Web/Components/Pages/Policies/PoliciesList.razor
@@ -81,7 +81,7 @@
                             {
                                 @foreach (var policyType in policyTypes)
                                 {
-                                    <MudSelectItem Value="@policyType.Id">@policyType.Name</MudSelectItem>
+                                    <MudSelectItem T="int?" Value="@((int?)policyType.Id)">@policyType.Name</MudSelectItem>
                                 }
                             }
                         </MudSelect>


### PR DESCRIPTION
…to nullable int

This fixes the InvalidCastException that occurred when MudSelectItem inferred T="int" from a non-nullable int value (policyType.Id) while the parent MudSelect was declared with T="int?".

The error was:
"Unable to cast object of type 'MudBlazor.MudSelect`1[System.Nullable`1[System.Int32]]' to type 'MudBlazor.MudSelect`1[System.Int32]'"

Changed the MudSelectItem to explicitly specify T="int?" and cast the Value to nullable int: Value="@((int?)policyType.Id)"

Location: PoliciesList.razor line 84