### PR TITLE
Fix AutoMapper policy creation mapping error

### DIFF
--- a/src/IAMS.Application/Features/Policies/Commands/CreatePolicy/CreatePolicyCommandHandler.cs
+++ b/src/IAMS.Application/Features/Policies/Commands/CreatePolicy/CreatePolicyCommandHandler.cs
@@ -55,6 +55,16 @@ namespace IAMS.Application.Features.Policies.Commands.CreatePolicy
 
                 var policy = _mapper.Map<Domain.Entities.Policy>(request.PolicyDto);
 
+                // Look up currency by code and set CurrencyId
+                var currency = await _unitOfWork.Currencies.GetByCodeAsync(request.PolicyDto.Currency);
+                if (currency == null)
+                {
+                    return Result<PolicyDto>.ValidationFailure(
+                        "Geçersiz para birimi",
+                        new List<string> { $"Para birimi '{request.PolicyDto.Currency}' bulunamadı" });
+                }
+                policy.CurrencyId = currency.Id;
+
                 // Generate policy number if not provided
                 if (string.IsNullOrEmpty(policy.PolicyNumber))
                 {

--- a/src/IAMS.Application/Features/Policies/Commands/UpdatePolicy/UpdatePolicyCommandHandler.cs
+++ b/src/IAMS.Application/Features/Policies/Commands/UpdatePolicy/UpdatePolicyCommandHandler.cs
@@ -73,6 +73,16 @@ namespace IAMS.Application.Features.Policies.Commands.UpdatePolicy
                 // Map the updated values
                 _mapper.Map(request.PolicyDto, existingPolicy);
 
+                // Look up currency by code and set CurrencyId
+                var currency = await _unitOfWork.Currencies.GetByCodeAsync(request.PolicyDto.Currency);
+                if (currency == null)
+                {
+                    return Result<PolicyDto>.ValidationFailure(
+                        "Geçersiz para birimi",
+                        new List<string> { $"Para birimi '{request.PolicyDto.Currency}' bulunamadı" });
+                }
+                existingPolicy.CurrencyId = currency.Id;
+
                 // Recalculate if policy type or insurance company changed, or if premium changed significantly
                 bool shouldRecalculate =
                     originalPolicyTypeId != existingPolicy.PolicyTypeId ||

--- a/src/IAMS.Application/Mappings/PolicyMappingProfile.cs
+++ b/src/IAMS.Application/Mappings/PolicyMappingProfile.cs
@@ -8,7 +8,8 @@ namespace IAMS.Application.Mappings
     {
         public PolicyMappingProfile()
         {
-            CreateMap<Policy, PolicyDto>();
+            CreateMap<Policy, PolicyDto>()
+                .ForMember(dest => dest.Currency, opt => opt.MapFrom(src => src.Currency != null ? src.Currency.Code : "TRY"));
 
             CreateMap<CreatePolicyDto, Policy>()
                 .ForMember(dest => dest.Id, opt => opt.Ignore())
@@ -16,6 +17,8 @@ namespace IAMS.Application.Mappings
                 .ForMember(dest => dest.ModifiedOn, opt => opt.Ignore())
                 .ForMember(dest => dest.Status, opt => opt.MapFrom(src => Domain.Enums.PolicyStatus.Draft))
                 .ForMember(dest => dest.CommissionAmount, opt => opt.Ignore())
+                .ForMember(dest => dest.CurrencyId, opt => opt.Ignore()) // Will be set in handler after currency lookup
+                .ForMember(dest => dest.Currency, opt => opt.Ignore()) // Navigation property, ignore during mapping
                 .ForMember(dest => dest.Customer, opt => opt.Ignore())
                 .ForMember(dest => dest.InsuranceCompany, opt => opt.Ignore())
                 .ForMember(dest => dest.PolicyType, opt => opt.Ignore())
@@ -31,6 +34,8 @@ namespace IAMS.Application.Mappings
                 .ForMember(dest => dest.CreatedOn, opt => opt.Ignore())
                 .ForMember(dest => dest.ModifiedOn, opt => opt.Ignore())
                 .ForMember(dest => dest.CommissionAmount, opt => opt.Ignore())
+                .ForMember(dest => dest.CurrencyId, opt => opt.Ignore()) // Will be set in handler after currency lookup
+                .ForMember(dest => dest.Currency, opt => opt.Ignore()) // Navigation property, ignore during mapping
                 .ForMember(dest => dest.Customer, opt => opt.Ignore())
                 .ForMember(dest => dest.InsuranceCompany, opt => opt.Ignore())
                 .ForMember(dest => dest.PolicyType, opt => opt.Ignore())


### PR DESCRIPTION
Resolves the AutoMapper.AutoMapperMappingException that occurred when mapping CreatePolicyDto/UpdatePolicyDto to Policy entity.

The issue was that the DTOs have a Currency property as a string (currency code like "TRY", "USD"), but the Policy entity has CurrencyId (int) and Currency (navigation property to Currency entity). AutoMapper was attempting to map the string directly to the Currency entity, which failed.

Changes made:
- Updated PolicyMappingProfile to ignore Currency navigation property and CurrencyId during DTO to Policy mappings
- Updated PolicyMappingProfile to map Currency.Code to Currency string in Policy to PolicyDto mapping
- Added currency lookup by code in CreatePolicyCommandHandler and UpdatePolicyCommandHandler
- Added validation to ensure the currency code exists before creating/updating a policy

This ensures proper mapping between the string currency code in DTOs and the CurrencyId in the Policy entity.