### PR TITLE
Fix EventCallback conversion errors with lambda expressions

### DIFF
--- a/src/IAMS.Web/Components/Pages/Policies/PolicyForm.razor
+++ b/src/IAMS.Web/Components/Pages/Policies/PolicyForm.razor
@@ -342,7 +342,7 @@
                                 <MudGrid>
                                     <MudItem xs="12" md="4">
                                         <MudNumericField Value="model.PremiumAmount"
-                                                       ValueChanged="@OnPremiumAmountChanged"
+                                                       ValueChanged="@((decimal value) => OnPremiumAmountChanged(value))"
                                                        Label="Prim Tutarı *"
                                                        Variant="Variant.Outlined"
                                                        Required="true"
@@ -356,7 +356,7 @@
                                     </MudItem>
                                     <MudItem xs="12" md="4">
                                         <MudNumericField Value="model.CommissionRate"
-                                                       ValueChanged="@OnCommissionRateChanged"
+                                                       ValueChanged="@((decimal value) => OnCommissionRateChanged(value))"
                                                        Label="Komisyon Oranı"
                                                        Variant="Variant.Outlined"
                                                        For="@(() => model.CommissionRate)"


### PR DESCRIPTION
Wrapped OnPremiumAmountChanged and OnCommissionRateChanged calls in lambda expressions to properly convert to EventCallback<decimal> type.

Changed from:
  ValueChanged="@OnPremiumAmountChanged"
To:
  ValueChanged="@((decimal value) => OnPremiumAmountChanged(value))"

Fixes CS1503 errors on lines 345 and 359.