### PR TITLE
Implement GetPolicyQueryHandler to fix MediatR registration error

### DIFF
--- a/src/IAMS.Application/Features/Policies/Queries/GetPolicy/GetPolicyQueryHandler.cs
+++ b/src/IAMS.Application/Features/Policies/Queries/GetPolicy/GetPolicyQueryHandler.cs
@@ -1,12 +1,48 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using AutoMapper;
+using IAMS.Application.DTOs.Policy;
+using IAMS.Application.Interfaces.Repositories;
+using IAMS.Application.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace IAMS.Application.Features.Policies.Queries.GetPolicy
 {
-    internal class GetPolicyQueryHandler
+    public class GetPolicyQueryHandler : IRequestHandler<GetPolicyQuery, Result<PolicyDto>>
     {
+        private readonly IPolicyRepository _policyRepository;
+        private readonly IMapper _mapper;
+        private readonly ILogger<GetPolicyQueryHandler> _logger;
+
+        public GetPolicyQueryHandler(
+            IPolicyRepository policyRepository,
+            IMapper mapper,
+            ILogger<GetPolicyQueryHandler> logger)
+        {
+            _policyRepository = policyRepository;
+            _mapper = mapper;
+            _logger = logger;
+        }
+
+        public async Task<Result<PolicyDto>> Handle(GetPolicyQuery request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var policy = await _policyRepository.GetPolicyByIdWithDetailsAsync(request.Id);
+
+                if (policy == null)
+                {
+                    return Result<PolicyDto>.NotFound($"Policy with ID {request.Id} not found");
+                }
+
+                var policyDto = _mapper.Map<PolicyDto>(policy);
+                return Result<PolicyDto>.Success(policyDto);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error loading policy with ID {PolicyId}", request.Id);
+                return Result<PolicyDto>.InternalError("Poliçe yüklenirken hata oluştu");
+            }
+        }
     }
 }

--- a/src/IAMS.Application/Interfaces/Repositories/IPolicyRepository.cs
+++ b/src/IAMS.Application/Interfaces/Repositories/IPolicyRepository.cs
@@ -7,6 +7,7 @@ namespace IAMS.Application.Interfaces.Repositories
     public interface IPolicyRepository : IRepository<Policy>
     {
         // Basic CRUD operations
+        Task<Policy?> GetPolicyByIdWithDetailsAsync(int id);
         Task<Policy?> GetByPolicyNumberAsync(string policyNumber);
         Task<List<Policy>> GetPoliciesByCustomerIdAsync(int customerId);
         Task<bool> PolicyNumberExistsAsync(string policyNumber, int? excludePolicyId = null);

--- a/src/IAMS.Persistence/Repositories/PolicyRepository.cs
+++ b/src/IAMS.Persistence/Repositories/PolicyRepository.cs
@@ -13,6 +13,16 @@ namespace IAMS.Persistence.Repositories
         {
         }
 
+        public async Task<Policy?> GetPolicyByIdWithDetailsAsync(int id)
+        {
+            return await _dbSet
+                .Include(p => p.Customer)
+                .Include(p => p.InsuranceCompany)
+                .Include(p => p.PolicyType)
+                .Include(p => p.Vehicle)
+                .FirstOrDefaultAsync(p => p.Id == id && !p.IsDeleted);
+        }
+
         public async Task<Policy?> GetByPolicyNumberAsync(string policyNumber)
         {
             return await _dbSet


### PR DESCRIPTION
The GetPolicyQueryHandler was an empty class, causing MediatR to fail to register it as a handler for GetPolicyQuery requests.

Changes:
- Implemented complete GetPolicyQueryHandler with proper error handling
- Added GetPolicyByIdWithDetailsAsync method to IPolicyRepository
- Implemented GetPolicyByIdWithDetailsAsync in PolicyRepository with proper navigation property includes (Customer, InsuranceCompany, PolicyType, Vehicle)
- Handler now uses the new method to load policy with all related entities
- Added AutoMapper to map Policy entity to PolicyDto
- Added proper logging and error messages