### PR TITLE
Remove GetConvertedAmount calls from Customer Report display

### DIFF
--- a/src/IAMS.Web/Components/Pages/Reports/CustomerReport.razor
+++ b/src/IAMS.Web/Components/Pages/Reports/CustomerReport.razor
@@ -289,10 +289,10 @@
                                 <MudTd DataLabel="Başlangıç">@context.StartDate.ToString("dd.MM.yyyy")</MudTd>
                                 <MudTd DataLabel="Bitiş">@context.EndDate.ToString("dd.MM.yyyy")</MudTd>
                                 <MudTd DataLabel="Prim" Style="text-align: right">
-                                    @GetConvertedAmount(context.PremiumAmount, context.Currency).ToString("N2")
+                                    @context.PremiumAmount.ToString("N2")
                                 </MudTd>
                                 <MudTd DataLabel="Komisyon" Style="text-align: right">
-                                    @GetConvertedAmount(context.CommissionAmount, context.Currency).ToString("N2")
+                                    @context.CommissionAmount.ToString("N2")
                                 </MudTd>
                                 <MudTd DataLabel="Durum" Style="text-align: center">
                                     <MudChip T="string" Size="Size.Small" Color="@GetPolicyStatusColor(context.Status)">


### PR DESCRIPTION
The GetConvertedAmount method was removed but two display calls remained. Since we're now filtering policies by currency instead of converting, we can display the amounts directly without any conversion.

Changed:
- Line 292: Display context.PremiumAmount directly
- Line 295: Display context.CommissionAmount directly

All policies shown in the table are already filtered by the selected currency, so no conversion is needed.