### PR TITLE
Fix currency display in policy details to show correct currency symbol

### DIFF
--- a/src/IAMS.Web/Components/Pages/Policies/PolicyDetails.razor
+++ b/src/IAMS.Web/Components/Pages/Policies/PolicyDetails.razor
@@ -75,7 +75,7 @@ else
                     <MudCard Class="pa-4">
                         <MudStack AlignItems="AlignItems.Center" Spacing="2">
                             <MudIcon Icon="@Icons.Material.Filled.AttachMoney" Size="Size.Large" Color="Color.Primary" />
-                            <MudText Typo="Typo.h4" Color="Color.Primary">@policy.PremiumAmount.ToString("C")</MudText>
+                            <MudText Typo="Typo.h4" Color="Color.Primary">@FormatCurrency(policy.PremiumAmount, policy.Currency)</MudText>
                             <MudText Typo="Typo.body1" Color="Color.Secondary">Prim Tutarı</MudText>
                         </MudStack>
                     </MudCard>
@@ -84,7 +84,7 @@ else
                     <MudCard Class="pa-4">
                         <MudStack AlignItems="AlignItems.Center" Spacing="2">
                             <MudIcon Icon="@Icons.Material.Filled.Paid" Size="Size.Large" Color="Color.Success" />
-                            <MudText Typo="Typo.h4" Color="Color.Success">@policy.CommissionAmount.ToString("C")</MudText>
+                            <MudText Typo="Typo.h4" Color="Color.Success">@FormatCurrency(policy.CommissionAmount, policy.Currency)</MudText>
                             <MudText Typo="Typo.body1" Color="Color.Secondary">
                                 Komisyon (%@policy.CommissionRate.ToString("F1"))
                             </MudText>
@@ -624,6 +624,24 @@ else
             "GBP" => "İngiliz Sterlini (£)",
             _ => currency
         };
+    }
+
+    private string GetCurrencySymbol(string currency)
+    {
+        return currency switch
+        {
+            "TRY" => "₺",
+            "USD" => "$",
+            "EUR" => "€",
+            "GBP" => "£",
+            _ => currency
+        };
+    }
+
+    private string FormatCurrency(decimal amount, string currency)
+    {
+        var symbol = GetCurrencySymbol(currency);
+        return $"{symbol}{amount:N2}";
     }
 
     private string GetPolicyDuration()


### PR DESCRIPTION
The policy details page was always displaying amounts with the dollar symbol ($) regardless of the actual policy currency. This was because .ToString("C") uses the default culture's currency format.

Changes:
- Added GetCurrencySymbol() helper method to map currency codes to symbols
- Added FormatCurrency() method to format amounts with the correct currency symbol
- Updated PremiumAmount display to use FormatCurrency() instead of .ToString("C")
- Updated CommissionAmount display to use FormatCurrency() instead of .ToString("C")

The policy details page now correctly shows:
- ₺ for TRY (Turkish Lira)
- $ for USD (US Dollar)
- € for EUR (Euro)
- £ for GBP (British Pound)

This ensures users see the correct currency symbol that matches the policy's actual currency, improving clarity and preventing confusion.