### PR TITLE
Fix commission percentage display on policies

### DIFF
--- a/src/IAMS.Application/Features/Policies/Commands/CreatePolicy/CreatePolicyCommandHandler.cs
+++ b/src/IAMS.Application/Features/Policies/Commands/CreatePolicy/CreatePolicyCommandHandler.cs
@@ -81,18 +81,31 @@ namespace IAMS.Application.Features.Policies.Commands.CreatePolicy
                         policy.PolicyNumber, policy.PremiumAmount);
                 }
 
-                // Calculate commission using database lookup
-                var (commissionAmount, commissionRate) = await _commissionCalculator.CalculateCommissionAsync(
-                    policy.PolicyTypeId,
-                    policy.InsuranceCompanyId,
-                    policy.PremiumAmount);
+                // Use user-provided commission rate if specified, otherwise lookup from database
+                if (policy.CommissionRate > 0)
+                {
+                    // User provided a commission rate - calculate amount based on it
+                    policy.CommissionAmount = policy.PremiumAmount * (policy.CommissionRate / 100);
 
-                policy.CommissionAmount = commissionAmount;
-                policy.CommissionRate = commissionRate;
+                    _logger.LogInformation(
+                        "Using user-provided commission rate for policy {PolicyNumber}: Rate={Rate}%, Amount={Amount}",
+                        policy.PolicyNumber, policy.CommissionRate, policy.CommissionAmount);
+                }
+                else
+                {
+                    // No rate provided - fall back to database lookup
+                    var (commissionAmount, commissionRate) = await _commissionCalculator.CalculateCommissionAsync(
+                        policy.PolicyTypeId,
+                        policy.InsuranceCompanyId,
+                        policy.PremiumAmount);
 
-                _logger.LogInformation(
-                    "Calculated commission for policy {PolicyNumber}: Rate={Rate}%, Amount={Amount}",
-                    policy.PolicyNumber, commissionRate, commissionAmount);
+                    policy.CommissionAmount = commissionAmount;
+                    policy.CommissionRate = commissionRate;
+
+                    _logger.LogInformation(
+                        "Calculated commission from database for policy {PolicyNumber}: Rate={Rate}%, Amount={Amount}",
+                        policy.PolicyNumber, commissionRate, commissionAmount);
+                }
 
                 // Validate business rules
                 policy.Validate();

--- a/src/IAMS.Application/Features/Policies/Commands/UpdatePolicy/UpdatePolicyCommandHandler.cs
+++ b/src/IAMS.Application/Features/Policies/Commands/UpdatePolicy/UpdatePolicyCommandHandler.cs
@@ -69,6 +69,7 @@ namespace IAMS.Application.Features.Policies.Commands.UpdatePolicy
                 var originalPolicyTypeId = existingPolicy.PolicyTypeId;
                 var originalInsuranceCompanyId = existingPolicy.InsuranceCompanyId;
                 var originalPremium = existingPolicy.PremiumAmount;
+                var originalCommissionRate = existingPolicy.CommissionRate;
 
                 // Map the updated values
                 _mapper.Map(request.PolicyDto, existingPolicy);
@@ -83,13 +84,25 @@ namespace IAMS.Application.Features.Policies.Commands.UpdatePolicy
                 }
                 existingPolicy.CurrencyId = currency.Id;
 
-                // Recalculate if policy type or insurance company changed, or if premium changed significantly
+                // Check if user explicitly changed the commission rate
+                bool commissionRateChanged = Math.Abs(originalCommissionRate - existingPolicy.CommissionRate) > 0.01m;
+
+                // Check if factors affecting commission calculation changed
                 bool shouldRecalculate =
                     originalPolicyTypeId != existingPolicy.PolicyTypeId ||
                     originalInsuranceCompanyId != existingPolicy.InsuranceCompanyId ||
                     Math.Abs(originalPremium - existingPolicy.PremiumAmount) > 0.01m;
 
-                if (shouldRecalculate)
+                if (commissionRateChanged)
+                {
+                    // User explicitly changed the commission rate - use it and recalculate amount only
+                    existingPolicy.CommissionAmount = existingPolicy.PremiumAmount * (existingPolicy.CommissionRate / 100);
+
+                    _logger.LogInformation(
+                        "Using user-provided commission rate for policy {PolicyNumber}: Rate={Rate}%, Amount={Amount}",
+                        existingPolicy.PolicyNumber, existingPolicy.CommissionRate, existingPolicy.CommissionAmount);
+                }
+                else if (shouldRecalculate)
                 {
                     _logger.LogInformation(
                         "Policy {PolicyNumber} requires recalculation due to changes",
@@ -102,7 +115,7 @@ namespace IAMS.Application.Features.Policies.Commands.UpdatePolicy
                         existingPolicy.PremiumAmount = await premiumCalculator.CalculatePremiumAsync(existingPolicy);
                     }
 
-                    // Recalculate commission
+                    // Recalculate commission from database since user didn't change the rate
                     var (commissionAmount, commissionRate) = await _commissionCalculator.CalculateCommissionAsync(
                         existingPolicy.PolicyTypeId,
                         existingPolicy.InsuranceCompanyId,
@@ -112,8 +125,8 @@ namespace IAMS.Application.Features.Policies.Commands.UpdatePolicy
                     existingPolicy.CommissionRate = commissionRate;
 
                     _logger.LogInformation(
-                        "Recalculated for policy {PolicyNumber}: Premium={Premium}, Commission={Commission}",
-                        existingPolicy.PolicyNumber, existingPolicy.PremiumAmount, commissionAmount);
+                        "Recalculated commission from database for policy {PolicyNumber}: Premium={Premium}, Rate={Rate}%, Amount={Amount}",
+                        existingPolicy.PolicyNumber, existingPolicy.PremiumAmount, commissionRate, commissionAmount);
                 }
 
                 existingPolicy.ModifiedOn = DateTime.UtcNow;


### PR DESCRIPTION
The user's commission percentage choice was being ignored during policy creation and updates. The system always used database-configured rates or defaulted to 10%, overwriting any user-specified values.

Changes:
- CreatePolicyCommandHandler: Check if user provided a commission rate (> 0) and use it; otherwise fall back to database lookup
- UpdatePolicyCommandHandler: Detect if user explicitly changed the commission rate and preserve it; only recalculate from database when other factors change but rate wasn't modified

This allows users to override commission rates while maintaining the database-driven rate system as a helpful default.