### PR TITLE
Fix currency totals to display in base currency (TRY)

### DIFF
--- a/src/IAMS.Persistence/Repositories/InsuranceCompanyRepository.cs
+++ b/src/IAMS.Persistence/Repositories/InsuranceCompanyRepository.cs
@@ -89,10 +89,11 @@ namespace IAMS.Persistence.Repositories
 
         public async Task<decimal> GetTotalPremiumAmountAsync(int companyId)
         {
+            // Sum in base currency (TRY) - use PremiumAmountInBaseCurrency if available, otherwise PremiumAmount * ExchangeRateToBase
             return await _context.Policies
                 .Where(p => p.InsuranceCompanyId == companyId &&
                            p.Status == PolicyStatus.Active && !p.IsDeleted)
-                .SumAsync(p => p.PremiumAmount);
+                .SumAsync(p => p.PremiumAmountInBaseCurrency ?? (p.PremiumAmount * (p.ExchangeRateToBase ?? 1)));
         }
 
         public async Task<int> GetActivePoliciesCountAsync(int id)
@@ -105,10 +106,11 @@ namespace IAMS.Persistence.Repositories
 
         public async Task<decimal> GetTotalCommissionsAsync(int id)
         {
+            // Sum commissions in base currency (TRY) - use CommissionAmount * ExchangeRateToBase
             return await _context.Policies
                 .Where(p => p.InsuranceCompanyId == id &&
                            p.Status == PolicyStatus.Active && !p.IsDeleted)
-                .SumAsync(p => p.CommissionAmount);
+                .SumAsync(p => p.CommissionAmount * (p.ExchangeRateToBase ?? 1));
         }
 
         public async Task<List<CurrencyBreakdownDto>> GetCurrencyBreakdownAsync(int companyId)

--- a/src/IAMS.Web/Components/Pages/InsuranceCompanies/InsuranceCompanyDetails.razor
+++ b/src/IAMS.Web/Components/Pages/InsuranceCompanies/InsuranceCompanyDetails.razor
@@ -97,10 +97,12 @@
                             <MudStack Spacing="2" AlignItems="AlignItems.Center">
                                 <MudIcon Icon="@Icons.Material.Filled.AttachMoney" Size="Size.Large" Color="Color.Success" />
                                 <MudText Typo="Typo.h4">@company.TotalPremiums.ToString("C")</MudText>
-                                <MudText Typo="Typo.subtitle2" Color="Color.Secondary">Toplam Prim</MudText>
+                                <MudText Typo="Typo.subtitle2" Color="Color.Secondary">Toplam Prim (TRY)</MudText>
                                 @if (company.CurrencyBreakdowns != null && company.CurrencyBreakdowns.Any())
                                 {
-                                    <MudStack Spacing="0" AlignItems="AlignItems.Center" Style="margin-top: 8px;">
+                                    <MudDivider Class="my-2" />
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary"><strong>Para Birimi Detayları:</strong></MudText>
+                                    <MudStack Spacing="0" AlignItems="AlignItems.Center" Style="margin-top: 4px;">
                                         @foreach (var breakdown in company.CurrencyBreakdowns)
                                         {
                                             <MudText Typo="Typo.caption" Color="Color.Secondary">
@@ -119,10 +121,12 @@
                             <MudStack Spacing="2" AlignItems="AlignItems.Center">
                                 <MudIcon Icon="@Icons.Material.Filled.Percent" Size="Size.Large" Color="Color.Warning" />
                                 <MudText Typo="Typo.h4">@company.TotalCommissions.ToString("C")</MudText>
-                                <MudText Typo="Typo.subtitle2" Color="Color.Secondary">Toplam Komisyon</MudText>
+                                <MudText Typo="Typo.subtitle2" Color="Color.Secondary">Toplam Komisyon (TRY)</MudText>
                                 @if (company.CurrencyBreakdowns != null && company.CurrencyBreakdowns.Any())
                                 {
-                                    <MudStack Spacing="0" AlignItems="AlignItems.Center" Style="margin-top: 8px;">
+                                    <MudDivider Class="my-2" />
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary"><strong>Para Birimi Detayları:</strong></MudText>
+                                    <MudStack Spacing="0" AlignItems="AlignItems.Center" Style="margin-top: 4px;">
                                         @foreach (var breakdown in company.CurrencyBreakdowns)
                                         {
                                             <MudText Typo="Typo.caption" Color="Color.Secondary">
@@ -277,18 +281,18 @@
                             <MudCard Elevation="1">
                                 <MudCardHeader>
                                     <CardHeaderContent>
-                                        <MudText Typo="Typo.h6">Mali Özet</MudText>
+                                        <MudText Typo="Typo.h6">Mali Özet (TRY)</MudText>
                                     </CardHeaderContent>
                                 </MudCardHeader>
                                 <MudCardContent>
                                     <MudSimpleTable Hover="true">
                                         <tbody>
                                             <tr>
-                                                <td><MudText Typo="Typo.body1">Toplam Prim Tutarı</MudText></td>
+                                                <td><MudText Typo="Typo.body1">Toplam Prim Tutarı (TRY)</MudText></td>
                                                 <td><MudText Typo="Typo.body1" Align="Align.Right">@company.TotalPremiums.ToString("C")</MudText></td>
                                             </tr>
                                             <tr>
-                                                <td><MudText Typo="Typo.body1">Toplam Komisyon</MudText></td>
+                                                <td><MudText Typo="Typo.body1">Toplam Komisyon (TRY)</MudText></td>
                                                 <td><MudText Typo="Typo.body1" Align="Align.Right">@company.TotalCommissions.ToString("C")</MudText></td>
                                             </tr>
                                             <tr>

--- a/src/IAMS.Web/Components/Pages/InsuranceCompanies/InsuranceCompanyList.razor
+++ b/src/IAMS.Web/Components/Pages/InsuranceCompanies/InsuranceCompanyList.razor
@@ -105,7 +105,7 @@
                     <MudCardContent>
                         <MudStack Row Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
                             <MudStack Spacing="1">
-                                <MudText Typo="Typo.subtitle2" Color="Color.Secondary">Toplam Prim</MudText>
+                                <MudText Typo="Typo.subtitle2" Color="Color.Secondary">Toplam Prim (TRY)</MudText>
                                 <MudText Typo="Typo.h4" Color="Color.Info">@totalPremiums.ToString("C")</MudText>
                             </MudStack>
                             <MudIcon Icon="@Icons.Material.Filled.AttachMoney" Size="Size.Large" Color="Color.Info" />
@@ -118,7 +118,7 @@
                     <MudCardContent>
                         <MudStack Row Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
                             <MudStack Spacing="1">
-                                <MudText Typo="Typo.subtitle2" Color="Color.Secondary">Toplam Komisyon</MudText>
+                                <MudText Typo="Typo.subtitle2" Color="Color.Secondary">Toplam Komisyon (TRY)</MudText>
                                 <MudText Typo="Typo.h4" Color="Color.Warning">@totalCommissions.ToString("C")</MudText>
                             </MudStack>
                             <MudIcon Icon="@Icons.Material.Filled.Percent" Size="Size.Large" Color="Color.Warning" />
@@ -182,7 +182,7 @@
                             </MudChip>
                         </CellTemplate>
                     </PropertyColumn>
-                    <PropertyColumn Property="x => x.TotalPremiums" Title="Toplam Prim">
+                    <PropertyColumn Property="x => x.TotalPremiums" Title="Toplam Prim (TRY)">
                         <CellTemplate>
                             <MudText Typo="Typo.body2">@context.Item.TotalPremiums.ToString("C")</MudText>
                         </CellTemplate>


### PR DESCRIPTION
This update corrects the calculation and display of total premiums and commissions to properly handle multi-currency operations by converting all values to the base currency (Turkish Lira - TRY).

Changes:
- Updated GetTotalPremiumAmountAsync to sum using PremiumAmountInBaseCurrency or PremiumAmount * ExchangeRateToBase for accurate TRY totals
- Updated GetTotalCommissionsAsync to sum using CommissionAmount * ExchangeRateToBase for accurate TRY commission totals
- Modified InsuranceCompanyDetails component to:
  * Clearly label totals as "(TRY)" in summary cards
  * Add "Para Birimi Detayları" section with divider in cards
  * Update "Mali Özet" tab title and labels to indicate TRY
- Modified InsuranceCompanyList component to:
  * Label total premium and commission cards as "(TRY)"
  * Update data grid column header to "Toplam Prim (TRY)"

This ensures users understand that totals represent converted values in the base currency, while the breakdown table shows original amounts in their respective currencies.