### PR TITLE
Add missing CurrencyMappingProfile for AutoMapper

### DIFF
--- a/src/IAMS.Application/Mappings/CurrencyMappingProfile.cs
+++ b/src/IAMS.Application/Mappings/CurrencyMappingProfile.cs
@@ -1,0 +1,36 @@
+using AutoMapper;
+using IAMS.Application.DTOs.Currency;
+using IAMS.Domain.Entities;
+
+namespace IAMS.Application.Mappings
+{
+    public class CurrencyMappingProfile : Profile
+    {
+        public CurrencyMappingProfile()
+        {
+            // Currency mappings
+            CreateMap<Currency, CurrencyDto>();
+            CreateMap<CurrencyDto, Currency>();
+
+            // CurrencyExchangeRate mappings
+            CreateMap<CurrencyExchangeRate, ExchangeRateDto>()
+                .ForMember(dest => dest.FromCurrencyCode, opt => opt.Ignore())
+                .ForMember(dest => dest.FromCurrencySymbol, opt => opt.Ignore())
+                .ForMember(dest => dest.ToCurrencyCode, opt => opt.Ignore())
+                .ForMember(dest => dest.ToCurrencySymbol, opt => opt.Ignore());
+
+            CreateMap<CreateExchangeRateDto, CurrencyExchangeRate>();
+
+            CreateMap<ExchangeRateDto, CurrencyExchangeRate>();
+
+            // Money DTO mapping
+            CreateMap<MoneyDto, CurrencyConversionDto>()
+                .ForMember(dest => dest.OriginalAmount, opt => opt.MapFrom(src => src.Amount))
+                .ForMember(dest => dest.OriginalCurrencyId, opt => opt.MapFrom(src => src.CurrencyId))
+                .ForMember(dest => dest.TargetCurrencyId, opt => opt.Ignore())
+                .ForMember(dest => dest.ConvertedAmount, opt => opt.Ignore())
+                .ForMember(dest => dest.ExchangeRate, opt => opt.Ignore())
+                .ForMember(dest => dest.CurrencyCode, opt => opt.Ignore());
+        }
+    }
+}


### PR DESCRIPTION
The TCMB endpoint was failing with 500 error because AutoMapper couldn't find mappings for:
- CreateExchangeRateDto -> CurrencyExchangeRate
- CurrencyExchangeRate -> ExchangeRateDto
- Currency -> CurrencyDto

This profile defines all necessary mappings for currency-related DTOs.