### PR TITLE
Fix vehicle details not appearing in policy details screen

### DIFF
--- a/src/IAMS.Persistence/Repositories/PolicyRepository.cs
+++ b/src/IAMS.Persistence/Repositories/PolicyRepository.cs
@@ -20,6 +20,13 @@ namespace IAMS.Persistence.Repositories
                 .Include(p => p.InsuranceCompany)
                 .Include(p => p.PolicyType)
                 .Include(p => p.Vehicle)
+                    .ThenInclude(v => v.Brand)
+                .Include(p => p.Vehicle)
+                    .ThenInclude(v => v.Model)
+                .Include(p => p.Vehicle)
+                    .ThenInclude(v => v.Customer)
+                .Include(p => p.Vehicle)
+                    .ThenInclude(v => v.Currency)
                 .Include(p => p.Currency)
                 .FirstOrDefaultAsync(p => p.Id == id && !p.IsDeleted);
         }


### PR DESCRIPTION
The Vehicle navigation property was being loaded but its related entities (Brand, Model, Customer, Currency) were not included. This caused the VehicleDto mapping to fail since it requires these properties to populate BrandName, ModelName, CustomerName, and Currency fields.

Changes:
- Added ThenInclude for Vehicle.Brand in GetPolicyByIdWithDetailsAsync
- Added ThenInclude for Vehicle.Model in GetPolicyByIdWithDetailsAsync
- Added ThenInclude for Vehicle.Customer in GetPolicyByIdWithDetailsAsync
- Added ThenInclude for Vehicle.Currency in GetPolicyByIdWithDetailsAsync

This ensures all vehicle-related data is properly loaded and displayed in the policy details component.