### PR TITLE
Add vehicle brand and model handling in GetOrCreateVehicleAsync

### DIFF
--- a/src/IAMS.Application/Features/Policies/Commands/ImportPolicies/ImportPoliciesCommandHandler.cs
+++ b/src/IAMS.Application/Features/Policies/Commands/ImportPolicies/ImportPoliciesCommandHandler.cs
@@ -329,11 +329,72 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
                 return vehicle;
             }
 
+            // Get or create vehicle brand
+            VehicleBrand? brand = null;
+            if (!string.IsNullOrEmpty(dto.VehicleBrand))
+            {
+                brand = await _unitOfWork.VehicleBrands.GetByNameAsync(dto.VehicleBrand);
+                if (brand == null)
+                {
+                    // Create new brand
+                    _logger.LogInformation("Creating new vehicle brand: {BrandName}", dto.VehicleBrand);
+                    brand = new VehicleBrand
+                    {
+                        Name = dto.VehicleBrand,
+                        Code = dto.VehicleBrand.ToUpperInvariant(),
+                        IsActive = true,
+                        DisplayOrder = 999,
+                        CreatedBy = userId,
+                        CreatedOn = DateTime.UtcNow,
+                        ModifiedBy = userId,
+                        ModifiedOn = DateTime.UtcNow
+                    };
+                    await _unitOfWork.VehicleBrands.AddAsync(brand);
+                    await _unitOfWork.SaveChangesAsync();
+                }
+            }
+
+            // Get or create vehicle model
+            VehicleModel? model = null;
+            if (brand != null && !string.IsNullOrEmpty(dto.VehicleModel))
+            {
+                model = await _unitOfWork.VehicleModels.GetByNameAndBrandIdAsync(dto.VehicleModel, brand.Id);
+                if (model == null)
+                {
+                    // Create new model
+                    _logger.LogInformation("Creating new vehicle model: {ModelName} for brand: {BrandName}",
+                        dto.VehicleModel, brand.Name);
+                    model = new VehicleModel
+                    {
+                        BrandId = brand.Id,
+                        Name = dto.VehicleModel,
+                        Code = dto.VehicleModel.ToUpperInvariant(),
+                        IsActive = true,
+                        DisplayOrder = 999,
+                        CreatedBy = userId,
+                        CreatedOn = DateTime.UtcNow,
+                        ModifiedBy = userId,
+                        ModifiedOn = DateTime.UtcNow
+                    };
+                    await _unitOfWork.VehicleModels.AddAsync(model);
+                    await _unitOfWork.SaveChangesAsync();
+                }
+            }
+
+            // Validate that we have both brand and model, or throw an error
+            if (brand == null || model == null)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot create vehicle without brand and model. Row: {dto.RowNumber}, Plate: {dto.PlateNumber}");
+            }
+
             // Auto-create vehicle from import data
             vehicle = new Vehicle
             {
                 CustomerId = customerId,
                 PlateNumber = dto.PlateNumber,
+                BrandId = brand.Id,
+                ModelId = model.Id,
                 ModelYear = dto.VehicleYear,
                 CreatedBy = userId,
                 CreatedOn = DateTime.UtcNow,

--- a/src/IAMS.Application/Interfaces/Repositories/IVehicleBrandRepository.cs
+++ b/src/IAMS.Application/Interfaces/Repositories/IVehicleBrandRepository.cs
@@ -6,5 +6,6 @@ namespace IAMS.Application.Interfaces.Repositories
     {
         Task<IEnumerable<VehicleBrand>> GetActiveBrandsAsync();
         Task<bool> BrandNameExistsAsync(string name, int? excludeBrandId = null);
+        Task<VehicleBrand?> GetByNameAsync(string name);
     }
 }

--- a/src/IAMS.Application/Interfaces/Repositories/IVehicleModelRepository.cs
+++ b/src/IAMS.Application/Interfaces/Repositories/IVehicleModelRepository.cs
@@ -7,5 +7,6 @@ namespace IAMS.Application.Interfaces.Repositories
         Task<IEnumerable<VehicleModel>> GetByBrandIdAsync(int brandId);
         Task<IEnumerable<VehicleModel>> GetActiveByBrandIdAsync(int brandId);
         Task<bool> ModelNameExistsAsync(int brandId, string name, int? excludeModelId = null);
+        Task<VehicleModel?> GetByNameAndBrandIdAsync(string name, int brandId);
     }
 }

--- a/src/IAMS.Persistence/Repositories/VehicleBrandRepository.cs
+++ b/src/IAMS.Persistence/Repositories/VehicleBrandRepository.cs
@@ -31,5 +31,12 @@ namespace IAMS.Persistence.Repositories
 
             return await query.AnyAsync();
         }
+
+        public async Task<VehicleBrand?> GetByNameAsync(string name)
+        {
+            return await _dbSet
+                .Where(b => !b.IsDeleted && b.Name == name)
+                .FirstOrDefaultAsync();
+        }
     }
 }

--- a/src/IAMS.Persistence/Repositories/VehicleModelRepository.cs
+++ b/src/IAMS.Persistence/Repositories/VehicleModelRepository.cs
@@ -42,5 +42,12 @@ namespace IAMS.Persistence.Repositories
 
             return await query.AnyAsync();
         }
+
+        public async Task<VehicleModel?> GetByNameAndBrandIdAsync(string name, int brandId)
+        {
+            return await _dbSet
+                .Where(m => !m.IsDeleted && m.Name == name && m.BrandId == brandId)
+                .FirstOrDefaultAsync();
+        }
     }
 }


### PR DESCRIPTION
- Added GetByNameAsync method to IVehicleBrandRepository and implementation
- Added GetByNameAndBrandIdAsync method to IVehicleModelRepository and implementation
- Updated GetOrCreateVehicleAsync to get or create vehicle brands and models
- Vehicle creation now requires brand and model, auto-creates them if they don't exist
- Brand and model are looked up by name from import data
- New brands and models are created with auto-generated codes and DisplayOrder 999
- Validates that both brand and model exist before creating vehicle

This ensures vehicles have proper relational data instead of just plate numbers.