### PR TITLE
Add missing policy fields to view components

### DIFF
--- a/src/IAMS.Application/DTOs/Policy/PolicyDto.cs
+++ b/src/IAMS.Application/DTOs/Policy/PolicyDto.cs
@@ -19,19 +19,19 @@ namespace IAMS.Application.DTOs.Policy
         public int? ParentPolicyId { get; set; }
 
         // Endorsement Information (Zeyilname)
+        public string InnerCode { get; set; } = "000"; // Z.No - 3-digit code: 000 for main, 001+ for endorsements
+        public StateType StateType { get; set; } // TIP column (P, T, V, R, X, Y)
         public bool IsEndorsement { get; set; }
         public string? EndorsementNumber { get; set; }
         public int? OriginalPolicyId { get; set; }
-        public string? BranchCode { get; set; }
+        public string? BranchCode { get; set; } // Kod column - External code for insurance type
 
         // Driver Information
-        public int? DriverAge { get; set; }
-        public DriverType? DriverType { get; set; }
+        public int? DriverAge { get; set; } // YAS column
+        public DriverType? DriverType { get; set; } // Sürücü - Single or Any
 
         // Marketer Information
-        public int? MarketerId { get; set; }
-        public string? MarketerCode { get; set; }
-        public string? MarketerName { get; set; }
+        public string? Marketer { get; set; } // Pazarlamacı Adı
 
         public DateTime StartDate { get; set; }
         public DateTime EndDate { get; set; }

--- a/src/IAMS.Web/Components/Pages/Policies/PoliciesList.razor
+++ b/src/IAMS.Web/Components/Pages/Policies/PoliciesList.razor
@@ -203,6 +203,24 @@
                 </ToolBarContent>
                 <Columns>
                     <PropertyColumn Property="x => x.PolicyNumber" Title="Poliçe No" />
+                    <TemplateColumn Title="Z.No">
+                        <CellTemplate>
+                            <div style="text-align: center;">
+                                <MudText Typo="Typo.body2">@context.Item.InnerCode</MudText>
+                                @if (context.Item.InnerCode != "000")
+                                {
+                                    <MudChip Size="Size.Small" Color="Color.Info" T="string">Zeyil</MudChip>
+                                }
+                            </div>
+                        </CellTemplate>
+                    </TemplateColumn>
+                    <TemplateColumn Title="TIP">
+                        <CellTemplate>
+                            <div style="text-align: center;">
+                                <MudText Typo="Typo.caption">@GetStateTypeShortText(context.Item.StateType)</MudText>
+                            </div>
+                        </CellTemplate>
+                    </TemplateColumn>
                     <TemplateColumn Title="Müşteri">
                         <CellTemplate>
                             <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
@@ -677,6 +695,20 @@
             PolicyStatus.Expired => "Süresi Dolmuş",
             PolicyStatus.Suspended => "Askıya Alınmış",
             _ => "Bilinmiyor"
+        };
+    }
+
+    private string GetStateTypeShortText(StateType stateType)
+    {
+        return stateType switch
+        {
+            StateType.YeniPolice => "P",
+            StateType.Tecdit => "T",
+            StateType.Ilave => "V",
+            StateType.Iade => "R",
+            StateType.Iptal => "X",
+            StateType.Yeniden => "Y",
+            _ => stateType.ToString()
         };
     }
 }

--- a/src/IAMS.Web/Components/Pages/Policies/PolicyDetails.razor
+++ b/src/IAMS.Web/Components/Pages/Policies/PolicyDetails.razor
@@ -119,6 +119,28 @@ else
                                     <MudText><strong>@policy.PolicyNumber</strong></MudText>
                                 </MudStack>
                                 <MudStack Row Justify="Justify.SpaceBetween">
+                                    <MudText>İç Kod (Z.No):</MudText>
+                                    <MudText>
+                                        <strong>@policy.InnerCode</strong>
+                                        @if (policy.InnerCode != "000")
+                                        {
+                                            <MudChip Size="Size.Small" Color="Color.Info" Class="ml-2">Zeyilname</MudChip>
+                                        }
+                                    </MudText>
+                                </MudStack>
+                                <MudStack Row Justify="Justify.SpaceBetween">
+                                    <MudText>Durum Tipi (TIP):</MudText>
+                                    <MudText><strong>@GetStateTypeText(policy.StateType)</strong></MudText>
+                                </MudStack>
+                                @if (!string.IsNullOrEmpty(policy.BranchCode))
+                                {
+                                    <MudStack Row Justify="Justify.SpaceBetween">
+                                        <MudText>Branş Kodu:</MudText>
+                                        <MudText><strong>@policy.BranchCode</strong></MudText>
+                                    </MudStack>
+                                }
+                                <MudDivider />
+                                <MudStack Row Justify="Justify.SpaceBetween">
                                     <MudText>Sigorta Şirketi:</MudText>
                                     <MudText><strong>@policy.InsuranceCompany?.Name</strong></MudText>
                                 </MudStack>
@@ -130,6 +152,13 @@ else
                                     <MudText>Para Birimi:</MudText>
                                     <MudText><strong>@GetCurrencyText(policy.Currency)</strong></MudText>
                                 </MudStack>
+                                @if (!string.IsNullOrEmpty(policy.Marketer))
+                                {
+                                    <MudStack Row Justify="Justify.SpaceBetween">
+                                        <MudText>Pazarlamacı:</MudText>
+                                        <MudText><strong>@policy.Marketer</strong></MudText>
+                                    </MudStack>
+                                }
                                 <MudDivider />
                                 <MudStack Row Justify="Justify.SpaceBetween">
                                     <MudText>Başlangıç Tarihi:</MudText>
@@ -261,6 +290,21 @@ else
                                         <MudStack Row Justify="Justify.SpaceBetween">
                                             <MudText>Güncel Değer:</MudText>
                                             <MudText><strong>@policy.Vehicle.CurrentValue.Value.ToString("N2") @policy.Vehicle.Currency</strong></MudText>
+                                        </MudStack>
+                                    }
+                                    <MudDivider />
+                                    @if (policy.DriverAge.HasValue)
+                                    {
+                                        <MudStack Row Justify="Justify.SpaceBetween">
+                                            <MudText>Sürücü Yaşı:</MudText>
+                                            <MudText><strong>@policy.DriverAge yaş</strong></MudText>
+                                        </MudStack>
+                                    }
+                                    @if (policy.DriverType.HasValue)
+                                    {
+                                        <MudStack Row Justify="Justify.SpaceBetween">
+                                            <MudText>Sürücü Tipi:</MudText>
+                                            <MudText><strong>@GetDriverTypeText(policy.DriverType.Value)</strong></MudText>
                                         </MudStack>
                                     }
                                 </MudStack>
@@ -786,6 +830,30 @@ else
             VehicleUsageType.Courier => "Kurye",
             VehicleUsageType.SchoolBus => "Okul Servisi",
             _ => usageType.ToString()
+        };
+    }
+
+    private string GetStateTypeText(StateType stateType)
+    {
+        return stateType switch
+        {
+            StateType.YeniPolice => "Yeni Poliçe",
+            StateType.Tecdit => "Tecdit",
+            StateType.Ilave => "İlave",
+            StateType.Iade => "İade",
+            StateType.Iptal => "İptal",
+            StateType.Yeniden => "Yeniden",
+            _ => stateType.ToString()
+        };
+    }
+
+    private string GetDriverTypeText(DriverType driverType)
+    {
+        return driverType switch
+        {
+            DriverType.Single => "Tek Sürücü",
+            DriverType.Any => "Sınırsız Sürücü",
+            _ => driverType.ToString()
         };
     }
 }


### PR DESCRIPTION
Added important policy fields that were missing from the UI views, improving visibility of policy details and endorsement information.

Changes to PolicyDto:
- Add InnerCode (Z.No) - 3-digit endorsement code (000 for main policy, 001+ for endorsements)
- Add StateType (TIP) - Policy state type (Yeni Poliçe, Tecdit, İptal, etc.)
- Consolidate Marketer fields into single Marketer property
- Add clarifying comments for DriverAge, DriverType, and BranchCode

Changes to PolicyDetails view:
- Display InnerCode with "Zeyilname" badge for endorsements
- Display StateType (TIP column)
- Display BranchCode (Kod column) when available
- Display Marketer (Pazarlamacı) when available
- Display DriverAge and DriverType in vehicle section
- Add GetStateTypeText helper for Turkish state type names
- Add GetDriverTypeText helper for driver type display

Changes to PoliciesList view:
- Add Z.No column showing InnerCode with "Zeyil" badge for endorsements
- Add TIP column showing StateType as single letter (P, T, V, R, X, Y)
- Add GetStateTypeShortText helper for compact display

These changes ensure all policy information from Excel imports is visible in the UI, supporting better policy management and tracking.