### PR TITLE
Fix policy entity to handle endorsement codes

### DIFF
--- a/src/IAMS.Application/Interfaces/Repositories/IPolicyRepository.cs
+++ b/src/IAMS.Application/Interfaces/Repositories/IPolicyRepository.cs
@@ -14,8 +14,11 @@ namespace IAMS.Application.Interfaces.Repositories
     {
         // Core CRUD operations only
         Task<Policy?> GetPolicyByIdWithDetailsAsync(int id);
-        Task<Policy?> GetByPolicyNumberAsync(string policyNumber);
+        Task<Policy?> GetByPolicyNumberAsync(string policyNumber); // Gets main policy (InnerCode = "000")
+        Task<Policy?> GetByPolicyNumberAndInnerCodeAsync(string policyNumber, string innerCode);
+        Task<List<Policy>> GetAllByPolicyNumberAsync(string policyNumber); // Gets all policies + endorsements
         Task<List<Policy>> GetPoliciesByCustomerIdAsync(int customerId);
         Task<bool> PolicyNumberExistsAsync(string policyNumber, int? excludePolicyId = null);
+        Task<bool> PolicyNumberAndInnerCodeExistsAsync(string policyNumber, string innerCode, int? excludePolicyId = null);
     }
 }

--- a/src/IAMS.Persistence/Configurations/PolicyConfiguration.cs
+++ b/src/IAMS.Persistence/Configurations/PolicyConfiguration.cs
@@ -26,7 +26,9 @@ namespace IAMS.Persistence.Configurations
             builder.Property(p => p.Notes)
                 .HasMaxLength(1000);
 
-            builder.HasIndex(p => p.PolicyNumber)
+            // Composite unique index on PolicyNumber and InnerCode
+            // This allows endorsements to share the same PolicyNumber but have different InnerCodes
+            builder.HasIndex(p => new { p.PolicyNumber, p.InnerCode })
                 .IsUnique()
                 .HasFilter("[IsDeleted] = 0");
 
@@ -86,7 +88,6 @@ namespace IAMS.Persistence.Configurations
                 .HasConversion<int>();
 
             builder.HasIndex(p => p.InnerCode);
-            builder.HasIndex(p => new { p.PolicyNumber, p.InnerCode });
 
             builder.Property(p => p.BranchCode)
                 .HasMaxLength(50);

--- a/src/IAMS.Persistence/Repositories/PolicyRepository.cs
+++ b/src/IAMS.Persistence/Repositories/PolicyRepository.cs
@@ -33,12 +33,36 @@ namespace IAMS.Persistence.Repositories
 
         public async Task<Policy?> GetByPolicyNumberAsync(string policyNumber)
         {
+            // Gets the main policy (InnerCode = "000") for a given policy number
             return await _dbSet
                 .Include(p => p.Customer)
                 .Include(p => p.InsuranceCompany)
                 .Include(p => p.PolicyType)
                 .Include(p => p.Currency)
-                .FirstOrDefaultAsync(p => p.PolicyNumber == policyNumber && !p.IsDeleted);
+                .FirstOrDefaultAsync(p => p.PolicyNumber == policyNumber && p.InnerCode == "000" && !p.IsDeleted);
+        }
+
+        public async Task<Policy?> GetByPolicyNumberAndInnerCodeAsync(string policyNumber, string innerCode)
+        {
+            return await _dbSet
+                .Include(p => p.Customer)
+                .Include(p => p.InsuranceCompany)
+                .Include(p => p.PolicyType)
+                .Include(p => p.Currency)
+                .FirstOrDefaultAsync(p => p.PolicyNumber == policyNumber && p.InnerCode == innerCode && !p.IsDeleted);
+        }
+
+        public async Task<List<Policy>> GetAllByPolicyNumberAsync(string policyNumber)
+        {
+            // Gets all policies (main + endorsements) for a given policy number
+            return await _dbSet
+                .Include(p => p.Customer)
+                .Include(p => p.InsuranceCompany)
+                .Include(p => p.PolicyType)
+                .Include(p => p.Currency)
+                .Where(p => p.PolicyNumber == policyNumber && !p.IsDeleted)
+                .OrderBy(p => p.InnerCode)
+                .ToListAsync();
         }
 
         public async Task<List<Policy>> GetPoliciesByCustomerIdAsync(int customerId)
@@ -54,7 +78,20 @@ namespace IAMS.Persistence.Repositories
 
         public async Task<bool> PolicyNumberExistsAsync(string policyNumber, int? excludePolicyId = null)
         {
-            var query = _dbSet.Where(p => !p.IsDeleted && p.PolicyNumber == policyNumber);
+            // Checks if a main policy (InnerCode = "000") exists with this policy number
+            var query = _dbSet.Where(p => !p.IsDeleted && p.PolicyNumber == policyNumber && p.InnerCode == "000");
+
+            if (excludePolicyId.HasValue)
+            {
+                query = query.Where(p => p.Id != excludePolicyId.Value);
+            }
+
+            return await query.AnyAsync();
+        }
+
+        public async Task<bool> PolicyNumberAndInnerCodeExistsAsync(string policyNumber, string innerCode, int? excludePolicyId = null)
+        {
+            var query = _dbSet.Where(p => !p.IsDeleted && p.PolicyNumber == policyNumber && p.InnerCode == innerCode);
 
             if (excludePolicyId.HasValue)
             {


### PR DESCRIPTION
BREAKING CHANGE: Policy uniqueness constraint changed from PolicyNumber alone to (PolicyNumber + InnerCode)

Changes:
- Updated PolicyConfiguration to use composite unique index on (PolicyNumber, InnerCode) instead of PolicyNumber alone
- This allows multiple endorsements to share the same PolicyNumber with different InnerCodes (000, 001, 002, etc.)
- Added new repository methods:
  - GetByPolicyNumberAndInnerCodeAsync: Get specific policy by both PolicyNumber and InnerCode
  - GetAllByPolicyNumberAsync: Get all policies (main + endorsements) for a PolicyNumber
  - PolicyNumberAndInnerCodeExistsAsync: Check if composite key exists
- Modified existing GetByPolicyNumberAsync to only return main policy (InnerCode = "000")
- Modified PolicyNumberExistsAsync to only check main policy existence

Database Migration Required:
After pulling these changes, run:
  dotnet ef migrations add FixPolicyCompositeKey --project src/IAMS.Persistence --startup-project src/IAMS.Web dotnet ef database update --project src/IAMS.Persistence --startup-project src/IAMS.Web

This migration will:
1. Drop the unique index on PolicyNumber
2. Create a unique index on (PolicyNumber, InnerCode)