### PR TITLE
Debug UpdateExchangeRatesFromTCMB 500 error

### DIFF
--- a/src/IAMS.MultiTenancy/Middleware/TenantMiddleware.cs
+++ b/src/IAMS.MultiTenancy/Middleware/TenantMiddleware.cs
@@ -45,6 +45,13 @@ namespace IAMS.MultiTenancy.Middleware
                 return;
             }
 
+            // Skip tenant middleware for currency endpoints (shared across tenants)
+            if (context.Request.Path.StartsWithSegments("/api/currencies"))
+            {
+                await _next(context);
+                return;
+            }
+
             try
             {
                 var tenantService = context.RequestServices.GetRequiredService<Interfaces.ITenantService>();


### PR DESCRIPTION
The UpdateExchangeRatesFromTCMB endpoint was returning 500 errors and breakpoints were not being hit because the TenantMiddleware was intercepting requests before they reached the controller.

Since currency endpoints (especially the TCMB exchange rate updater) are system-wide utilities that should be shared across all tenants, they should skip tenant validation.

Added skip condition for /api/currencies path, following the same pattern used for other shared endpoints like /api/parametric and /api/vehicles.