### PR TITLE
Remove customer email from policy list in insurance company details

### DIFF
--- a/src/IAMS.Web/Components/Pages/InsuranceCompanies/InsuranceCompanyDetails.razor
+++ b/src/IAMS.Web/Components/Pages/InsuranceCompanies/InsuranceCompanyDetails.razor
@@ -322,10 +322,7 @@
                                         <CellTemplate>
                                             @if (context.Item.Customer != null)
                                             {
-                                                <MudStack Spacing="0">
-                                                    <MudText Typo="Typo.body2">@($"{context.Item.Customer.FirstName} {context.Item.Customer.LastName}")</MudText>
-                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@context.Item.Customer.Email</MudText>
-                                                </MudStack>
+                                                <MudText Typo="Typo.body2">@($"{context.Item.Customer.FirstName} {context.Item.Customer.LastName}")</MudText>
                                             }
                                         </CellTemplate>
                                     </TemplateColumn>


### PR DESCRIPTION
Cleaned up the policy list display by removing customer email from the Müşteri column, now showing only customer's full name for a cleaner interface.