### PR TITLE
Store vehicle data as strings during import

### DIFF
--- a/src/IAMS.Application/DTOs/Vehicle/CreateVehicleDto.cs
+++ b/src/IAMS.Application/DTOs/Vehicle/CreateVehicleDto.cs
@@ -14,8 +14,10 @@ namespace IAMS.Application.DTOs.Vehicle
         public string ChassisNumber { get; set; } = string.Empty;
         public string? EngineNumber { get; set; }
         public string? RegistrationNumber { get; set; }
-        public int BrandId { get; set; }
-        public int ModelId { get; set; }
+        public int? BrandId { get; set; }
+        public string? BrandName { get; set; }
+        public int? ModelId { get; set; }
+        public string? ModelName { get; set; }
         public int? ModelYear { get; set; }
         public VehicleType VehicleType { get; set; }
         public VehicleFuelType FuelType { get; set; }

--- a/src/IAMS.Application/Features/Policies/Commands/ImportPolicies/ImportPoliciesCommandHandler.cs
+++ b/src/IAMS.Application/Features/Policies/Commands/ImportPolicies/ImportPoliciesCommandHandler.cs
@@ -364,43 +364,15 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
                 return vehicle;
             }
 
-            // Try to find brand and model if provided
-            int? brandId = null;
-            int? modelId = null;
-
-            if (!string.IsNullOrEmpty(dto.VehicleBrand))
-            {
-                var brand = await _unitOfWork.VehicleBrands
-                    .FindAsync(b => b.Name.ToLower() == dto.VehicleBrand.ToLower() && !b.IsDeleted);
-
-                if (brand != null && brand.Any())
-                {
-                    brandId = brand.First().Id;
-
-                    // If brand found and model provided, try to find model
-                    if (!string.IsNullOrEmpty(dto.VehicleModel) && brandId.HasValue)
-                    {
-                        var model = await _unitOfWork.VehicleModels
-                            .FindAsync(m => m.BrandId == brandId.Value &&
-                                          m.Name.ToLower() == dto.VehicleModel.ToLower() &&
-                                          !m.IsDeleted);
-
-                        if (model != null && model.Any())
-                        {
-                            modelId = model.First().Id;
-                        }
-                    }
-                }
-            }
-
             // Auto-create vehicle from import data
-            // BrandId and ModelId are now optional - only plaka is required for traffic policies
+            // Store brand and model as raw strings from import
+            // Only plate number is required for traffic policies
             vehicle = new Vehicle
             {
                 CustomerId = customerId,
                 PlateNumber = dto.PlateNumber,
-                BrandId = brandId,
-                ModelId = modelId,
+                BrandName = dto.VehicleBrand,
+                ModelName = dto.VehicleModel,
                 ModelYear = dto.VehicleYear,
                 CreatedBy = userId,
                 CreatedOn = DateTime.UtcNow,

--- a/src/IAMS.Application/Features/Vehicles/Commands/CreateVehicle/CreateVehicleCommandHandler.cs
+++ b/src/IAMS.Application/Features/Vehicles/Commands/CreateVehicle/CreateVehicleCommandHandler.cs
@@ -40,23 +40,29 @@ namespace IAMS.Application.Features.Vehicles.Commands.CreateVehicle
                     return Result<VehicleDto>.NotFound($"Customer with ID {request.VehicleDto.CustomerId} not found");
                 }
 
-                // Verify brand exists
-                var brand = await _unitOfWork.VehicleBrands.GetByIdAsync(request.VehicleDto.BrandId);
-                if (brand == null)
+                // Verify brand exists (optional - only if BrandId is provided)
+                if (request.VehicleDto.BrandId.HasValue)
                 {
-                    return Result<VehicleDto>.NotFound($"Vehicle brand with ID {request.VehicleDto.BrandId} not found");
+                    var brand = await _unitOfWork.VehicleBrands.GetByIdAsync(request.VehicleDto.BrandId.Value);
+                    if (brand == null)
+                    {
+                        return Result<VehicleDto>.NotFound($"Vehicle brand with ID {request.VehicleDto.BrandId} not found");
+                    }
                 }
 
-                // Verify model exists and belongs to brand
-                var model = await _unitOfWork.VehicleModels.GetByIdAsync(request.VehicleDto.ModelId);
-                if (model == null)
+                // Verify model exists and belongs to brand (optional - only if ModelId is provided)
+                if (request.VehicleDto.ModelId.HasValue)
                 {
-                    return Result<VehicleDto>.NotFound($"Vehicle model with ID {request.VehicleDto.ModelId} not found");
-                }
+                    var model = await _unitOfWork.VehicleModels.GetByIdAsync(request.VehicleDto.ModelId.Value);
+                    if (model == null)
+                    {
+                        return Result<VehicleDto>.NotFound($"Vehicle model with ID {request.VehicleDto.ModelId} not found");
+                    }
 
-                if (model.BrandId != request.VehicleDto.BrandId)
-                {
-                    return Result<VehicleDto>.Failure("Model does not belong to the specified brand", string.Empty);
+                    if (request.VehicleDto.BrandId.HasValue && model.BrandId != request.VehicleDto.BrandId.Value)
+                    {
+                        return Result<VehicleDto>.Failure("Model does not belong to the specified brand", string.Empty);
+                    }
                 }
 
                 // Check if plate number already exists

--- a/src/IAMS.Application/Mappings/VehicleMappingProfile.cs
+++ b/src/IAMS.Application/Mappings/VehicleMappingProfile.cs
@@ -66,8 +66,8 @@ namespace IAMS.Application.Mappings
 
             // Vehicle mappings
             CreateMap<Vehicle, VehicleDto>()
-                .ForMember(dest => dest.BrandName, opt => opt.MapFrom(src => src.Brand.Name))
-                .ForMember(dest => dest.ModelName, opt => opt.MapFrom(src => src.Model.Name))
+                .ForMember(dest => dest.BrandName, opt => opt.MapFrom(src => src.BrandName ?? src.Brand.Name ?? string.Empty))
+                .ForMember(dest => dest.ModelName, opt => opt.MapFrom(src => src.ModelName ?? src.Model.Name ?? string.Empty))
                 .ForMember(dest => dest.CustomerName, opt => opt.MapFrom(src => src.Customer != null ? $"{src.Customer.FirstName} {src.Customer.LastName}" : string.Empty))
                 .ForMember(dest => dest.Currency, opt => opt.MapFrom(src => src.Currency != null ? src.Currency.Code : "TRY"))
                 .ForMember(dest => dest.FullName, opt => opt.MapFrom(src => src.FullName));

--- a/src/IAMS.Domain/Entities/Vehicle.cs
+++ b/src/IAMS.Domain/Entities/Vehicle.cs
@@ -17,7 +17,9 @@ namespace IAMS.Domain.Entities
 
         // Vehicle Details
         public int? BrandId { get; set; } // Marka (parametric) - Optional for traffic policies
+        public string? BrandName { get; set; } // Raw brand name from import
         public int? ModelId { get; set; } // Model (parametric) - Optional for traffic policies
+        public string? ModelName { get; set; } // Raw model name from import
         public int? ModelYear { get; set; } // Model Yılı
         public VehicleType VehicleType { get; set; } // Araç Tipi
         public VehicleFuelType FuelType { get; set; } // Yakıt Tipi
@@ -58,6 +60,6 @@ namespace IAMS.Domain.Entities
         // Computed Properties
         public int VehicleAge => ModelYear.HasValue ? DateTime.Today.Year - ModelYear.Value : 0;
         public bool IsInspectionDue => NextInspectionDate.HasValue && NextInspectionDate.Value <= DateTime.Today.AddDays(30);
-        public string FullName => $"{Brand?.Name} {Model?.Name} - {PlateNumber}";
+        public string FullName => $"{BrandName ?? Brand?.Name} {ModelName ?? Model?.Name} - {PlateNumber}".Trim();
     }
 }


### PR DESCRIPTION
- Add BrandName and ModelName string fields to Vehicle entity
- Remove brand/model lookup logic from policy import process
- Store raw vehicle brand/model strings as they come from imports
- Make BrandId/ModelId optional in CreateVehicleDto
- Update VehicleMappingProfile to prefer string fields over navigation properties
- Update Vehicle.FullName to use string fields with fallback to entities

This allows importing policies with vehicle data that doesn't match database brand/model entities, preserving original data exactly as imported.