### PR TITLE
Fix MudFileUpload to use ActivatorContent instead of ButtonTemplate

### DIFF
--- a/src/IAMS.Web/Components/Pages/Policies/PolicyImport.razor
+++ b/src/IAMS.Web/Components/Pages/Policies/PolicyImport.razor
@@ -47,15 +47,14 @@
                             }
                         </MudSelect>
 
-                        <MudFileUpload T="IBrowserFile" FilesChanged="OnFileSelected" Accept=".xlsx,.xls">
-                            <ButtonTemplate>
-                                <MudButton HtmlTag="label"
-                                           Variant="Variant.Filled"
+                        <MudFileUpload T="IBrowserFile" OnFilesChanged="OnFileSelected" Accept=".xlsx,.xls">
+                            <ActivatorContent>
+                                <MudButton Variant="Variant.Filled"
                                            Color="Color.Primary"
                                            StartIcon="@Icons.Material.Filled.CloudUpload">
                                     Dosya Seç
                                 </MudButton>
-                            </ButtonTemplate>
+                            </ActivatorContent>
                         </MudFileUpload>
 
                         @if (selectedFile != null)
@@ -247,9 +246,9 @@
         }
     }
 
-    private void OnFileSelected(IBrowserFile file)
+    private void OnFileSelected(InputFileChangeEventArgs e)
     {
-        selectedFile = file;
+        selectedFile = e.File;
     }
 
     private async Task ParseFile()


### PR DESCRIPTION
- Changed ButtonTemplate to ActivatorContent (correct template for MudFileUpload)
- Changed FilesChanged to OnFilesChanged event
- Updated OnFileSelected to accept InputFileChangeEventArgs
- Removed HtmlTag='label' as it's not needed with ActivatorContent

This is the proper way to use MudFileUpload with a custom button.