### PR TITLE
Read tenant connection strings from database instead of appsettings

### DIFF
--- a/src/IAMS.Api/Program.cs
+++ b/src/IAMS.Api/Program.cs
@@ -211,8 +211,8 @@ app.UseHttpsRedirection();
 
 app.UseCors("DefaultPolicy");
 
-// 6. Multi-tenancy middleware - disabled (each tenant uses their own database via connection string)
-// app.UseMultiTenancy();
+// 6. Multi-tenancy middleware - reads tenant info and connection strings from database
+app.UseMultiTenancy();
 
 // 7. Authentication & Authorization
 app.UseAuthentication();

--- a/src/IAMS.MultiTenancy/Data/TenantDbContext.cs
+++ b/src/IAMS.MultiTenancy/Data/TenantDbContext.cs
@@ -132,7 +132,7 @@ namespace IAMS.MultiTenancy.Data
                     Id = 1,
                     Name = "Default Insurance Agency",
                     Identifier = "default",
-                    ConnectionString = "Data Source=localhost;Initial Catalog=TenantDb;Integrated Security=True;Trust Server Certificate=True",
+                    ConnectionString = "Data Source=localhost;Initial Catalog=DefaultAgencyDb;Integrated Security=True;Trust Server Certificate=True",
                     IsActive = true,
                     CreatedOn = seedDate,
                     SubscriptionPlan = "Premium",

--- a/src/IAMS.MultiTenancy/Extensions/ServiceCollectionExtentions.cs
+++ b/src/IAMS.MultiTenancy/Extensions/ServiceCollectionExtentions.cs
@@ -26,7 +26,7 @@ namespace IAMS.MultiTenancy.Extensions
             services.AddMemoryCache();
 
             // Register multi-tenancy core services
-            // services.AddScoped<ITenantService, TenantService>(); // Not needed when middleware is disabled
+            services.AddScoped<ITenantService, TenantService>();
             services.AddScoped<ITenantContextAccessor, TenantContextAccessor>();
 
             // Register module management service

--- a/src/IAMS.MultiTenancy/Services/TenantService.cs
+++ b/src/IAMS.MultiTenancy/Services/TenantService.cs
@@ -1,0 +1,223 @@
+using IAMS.MultiTenancy.Data;
+using IAMS.MultiTenancy.Entities;
+using IAMS.MultiTenancy.Interfaces;
+using IAMS.MultiTenancy.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace IAMS.MultiTenancy.Services
+{
+    /// <summary>
+    /// Service for managing tenant metadata stored in the master database.
+    /// Reads tenant connection strings from the Tenants table instead of appsettings.
+    /// </summary>
+    public class TenantService : ITenantService
+    {
+        private readonly TenantDbContext _context;
+        private readonly ITenantContextAccessor _tenantContextAccessor;
+        private readonly IMemoryCache _cache;
+        private readonly ILogger<TenantService> _logger;
+        private readonly TimeSpan _cacheExpiration = TimeSpan.FromMinutes(30);
+
+        private const string TenantCacheKeyPrefix = "Tenant_";
+        private const string AllTenantsCacheKey = "AllActiveTenants";
+
+        public TenantService(
+            TenantDbContext context,
+            ITenantContextAccessor tenantContextAccessor,
+            IMemoryCache cache,
+            ILogger<TenantService> logger)
+        {
+            _context = context;
+            _tenantContextAccessor = tenantContextAccessor;
+            _cache = cache;
+            _logger = logger;
+        }
+
+        public async Task<Tenant> GetTenantAsync(string identifier)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                _logger.LogWarning("GetTenantAsync called with null/empty identifier");
+                return null;
+            }
+
+            var cacheKey = $"{TenantCacheKeyPrefix}{identifier}";
+
+            if (_cache.TryGetValue(cacheKey, out Tenant cachedTenant))
+            {
+                _logger.LogDebug("Tenant {Identifier} found in cache", identifier);
+                return cachedTenant;
+            }
+
+            _logger.LogDebug("Loading tenant {Identifier} from database", identifier);
+
+            var tenantEntity = await _context.Tenants
+                .AsNoTracking()
+                .Include(t => t.TenantModules)
+                .FirstOrDefaultAsync(t => t.Identifier == identifier && !t.IsDeleted);
+
+            if (tenantEntity == null)
+            {
+                _logger.LogWarning("Tenant {Identifier} not found in database", identifier);
+                return null;
+            }
+
+            var tenant = MapToTenant(tenantEntity);
+
+            _cache.Set(cacheKey, tenant, _cacheExpiration);
+            _logger.LogDebug("Tenant {Identifier} cached", identifier);
+
+            return tenant;
+        }
+
+        public async Task<Tenant> GetTenantByIdAsync()
+        {
+            var tenantId = _tenantContextAccessor.CurrentTenantId;
+            if (tenantId == null)
+            {
+                _logger.LogWarning("GetTenantByIdAsync called but no tenant context");
+                return null;
+            }
+
+            var cacheKey = $"{TenantCacheKeyPrefix}Id_{tenantId}";
+
+            if (_cache.TryGetValue(cacheKey, out Tenant cachedTenant))
+            {
+                return cachedTenant;
+            }
+
+            var tenantEntity = await _context.Tenants
+                .AsNoTracking()
+                .Include(t => t.TenantModules)
+                .FirstOrDefaultAsync(t => t.Id == tenantId.Value && !t.IsDeleted);
+
+            if (tenantEntity == null)
+            {
+                return null;
+            }
+
+            var tenant = MapToTenant(tenantEntity);
+            _cache.Set(cacheKey, tenant, _cacheExpiration);
+
+            return tenant;
+        }
+
+        public async Task<List<Tenant>> GetAllActiveTenantsAsync()
+        {
+            if (_cache.TryGetValue(AllTenantsCacheKey, out List<Tenant> cachedTenants))
+            {
+                return cachedTenants;
+            }
+
+            var tenantEntities = await _context.Tenants
+                .AsNoTracking()
+                .Include(t => t.TenantModules)
+                .Where(t => t.IsActive && !t.IsDeleted)
+                .ToListAsync();
+
+            var tenants = tenantEntities.Select(MapToTenant).ToList();
+
+            _cache.Set(AllTenantsCacheKey, tenants, _cacheExpiration);
+            _logger.LogDebug("Cached {Count} active tenants", tenants.Count);
+
+            return tenants;
+        }
+
+        public Task InvalidateTenantCacheAsync(string identifier)
+        {
+            var cacheKey = $"{TenantCacheKeyPrefix}{identifier}";
+            _cache.Remove(cacheKey);
+            _cache.Remove(AllTenantsCacheKey);
+            _logger.LogInformation("Invalidated cache for tenant {Identifier}", identifier);
+            return Task.CompletedTask;
+        }
+
+        public Task InvalidateTenantCacheAsync()
+        {
+            var tenantId = _tenantContextAccessor.CurrentTenantId;
+            if (tenantId != null)
+            {
+                var cacheKey = $"{TenantCacheKeyPrefix}Id_{tenantId}";
+                _cache.Remove(cacheKey);
+            }
+            _cache.Remove(AllTenantsCacheKey);
+            return Task.CompletedTask;
+        }
+
+        public Tenant GetCurrentTenant()
+        {
+            return _tenantContextAccessor.CurrentTenant;
+        }
+
+        public int? GetCurrentTenantId()
+        {
+            return _tenantContextAccessor.CurrentTenantId;
+        }
+
+        public bool IsModuleEnabledForCurrentTenant(string moduleName)
+        {
+            return _tenantContextAccessor.IsModuleEnabled(moduleName);
+        }
+
+        public async Task UpdateTenantModuleAsync(string moduleName, bool isEnabled)
+        {
+            var tenantId = _tenantContextAccessor.CurrentTenantId;
+            if (tenantId == null)
+            {
+                throw new InvalidOperationException("No tenant context available");
+            }
+
+            var module = await _context.TenantModules
+                .FirstOrDefaultAsync(m => m.TenantId == tenantId.Value && m.ModuleName == moduleName);
+
+            if (module == null)
+            {
+                module = new TenantModule
+                {
+                    TenantId = tenantId.Value,
+                    ModuleName = moduleName,
+                    IsEnabled = isEnabled,
+                    CreatedOn = DateTime.UtcNow
+                };
+                _context.TenantModules.Add(module);
+            }
+            else
+            {
+                module.IsEnabled = isEnabled;
+                module.ModifiedOn = DateTime.UtcNow;
+            }
+
+            await _context.SaveChangesAsync();
+            await InvalidateTenantCacheAsync();
+
+            _logger.LogInformation("Updated module {ModuleName} to {IsEnabled} for tenant {TenantId}",
+                moduleName, isEnabled, tenantId);
+        }
+
+        private static Tenant MapToTenant(TenantEntity entity)
+        {
+            return new Tenant
+            {
+                Id = entity.Id,
+                Name = entity.Name,
+                Identifier = entity.Identifier,
+                ConnectionString = entity.ConnectionString,
+                IsActive = entity.IsActive,
+                SubscriptionPlan = entity.SubscriptionPlan,
+                MaxUsers = entity.MaxUsers,
+                MaxStorageBytes = entity.MaxStorageBytes,
+                ContactEmail = entity.ContactEmail,
+                TimeZone = entity.TimeZone,
+                Currency = entity.Currency,
+                Language = entity.Language,
+                EnabledModules = entity.TenantModules?
+                    .Where(m => m.IsEnabled)
+                    .Select(m => m.ModuleName)
+                    .ToList() ?? new List<string>(),
+                Settings = new Dictionary<string, string>()
+            };
+        }
+    }
+}

--- a/src/IAMS.Persistence/Services/TenantDatabaseService.cs
+++ b/src/IAMS.Persistence/Services/TenantDatabaseService.cs
@@ -1,4 +1,5 @@
-﻿using IAMS.Shared.Interfaces;
+using IAMS.Shared.Interfaces;
+using IAMS.MultiTenancy.Data;
 using IAMS.Persistence.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -6,15 +7,23 @@ using Microsoft.Extensions.Logging;
 
 namespace IAMS.Persistence.Services
 {
+    /// <summary>
+    /// Service for managing tenant databases.
+    /// Reads connection strings from the master database (Tenants table) instead of appsettings.
+    /// Falls back to appsettings TenantConnections only if not found in database.
+    /// </summary>
     public class TenantDatabaseService : ITenantDatabaseService
     {
+        private readonly TenantDbContext _masterDb;
         private readonly IConfiguration _configuration;
         private readonly ILogger<TenantDatabaseService> _logger;
 
         public TenantDatabaseService(
+            TenantDbContext masterDb,
             IConfiguration configuration,
             ILogger<TenantDatabaseService> logger)
         {
+            _masterDb = masterDb;
             _configuration = configuration;
             _logger = logger;
         }
@@ -23,7 +32,7 @@ namespace IAMS.Persistence.Services
         {
             try
             {
-                var connectionString = GetTenantConnectionString(tenantIdentifier);
+                var connectionString = await GetTenantConnectionStringAsync(tenantIdentifier);
 
                 var options = new DbContextOptionsBuilder<ApplicationDbContext>()
                     .UseSqlServer(connectionString)
@@ -57,32 +66,51 @@ namespace IAMS.Persistence.Services
 
         public async Task CreateTenantDatabaseAsync(string tenantIdentifier)
         {
-            var connectionString = GetTenantConnectionString(tenantIdentifier);
+            var connectionString = await GetTenantConnectionStringAsync(tenantIdentifier);
 
             var options = new DbContextOptionsBuilder<ApplicationDbContext>()
                 .UseSqlServer(connectionString)
                 .Options;
 
             using var context = new ApplicationDbContext(options, null);
-           // await context.Database.EnsureCreatedAsync();
+            // await context.Database.EnsureCreatedAsync();
 
             _logger.LogInformation("Created database for tenant {TenantIdentifier}", tenantIdentifier);
         }
 
-        private string GetTenantConnectionString(string tenantIdentifier)
+        /// <summary>
+        /// Gets the connection string for a tenant.
+        /// Priority: 1) Database (Tenants table) 2) appsettings TenantConnections 3) Default with replaced DB name
+        /// </summary>
+        private async Task<string> GetTenantConnectionStringAsync(string tenantIdentifier)
         {
+            // 1. Try to get from database (recommended for production)
+            var tenant = await _masterDb.Tenants
+                .AsNoTracking()
+                .FirstOrDefaultAsync(t => t.Identifier == tenantIdentifier && !t.IsDeleted && t.IsActive);
+
+            if (tenant != null && !string.IsNullOrEmpty(tenant.ConnectionString))
+            {
+                _logger.LogDebug("Using database connection string for tenant {TenantIdentifier}", tenantIdentifier);
+                return tenant.ConnectionString;
+            }
+
+            // 2. Fallback to appsettings TenantConnections (for backwards compatibility)
             var tenantConnections = _configuration.GetSection("TenantConnections");
             var connectionString = tenantConnections[tenantIdentifier];
 
             if (!string.IsNullOrEmpty(connectionString))
             {
+                _logger.LogDebug("Using appsettings TenantConnections for tenant {TenantIdentifier}", tenantIdentifier);
                 return connectionString;
             }
 
+            // 3. Fallback: use DefaultConnection with tenant identifier as database name
             var defaultConnection = _configuration.GetConnectionString("DefaultConnection");
             if (!string.IsNullOrEmpty(defaultConnection))
             {
-                return defaultConnection.Replace("ApplicationDb", $"{tenantIdentifier}");
+                _logger.LogDebug("Using modified DefaultConnection for tenant {TenantIdentifier}", tenantIdentifier);
+                return defaultConnection.Replace("ApplicationDb", tenantIdentifier);
             }
 
             throw new InvalidOperationException($"No connection string found for tenant '{tenantIdentifier}'");


### PR DESCRIPTION
Implemented dynamic tenant resolution that reads connection strings from the Tenants table in the master database (TenantDb).

Changes:
- Create TenantService implementation that loads tenants from database
- TenantService caches tenant info with 30-minute expiration
- Update TenantDatabaseService to query database for connection strings
- Falls back to appsettings TenantConnections for backwards compatibility
- Register TenantService in MultiTenancy DI
- Enable tenant middleware in API (was disabled)
- Fix seed data to use correct tenant database name

Connection string resolution priority:
1. Database (Tenants.ConnectionString) - recommended for production
2. appsettings TenantConnections - backwards compatibility
3. DefaultConnection with modified database name - fallback

This allows adding new agencies without redeploying the application.

https://claude.ai/code/session_018dajWUf2RmHrEohPJWzQZy