### PR TITLE
Remove all incorrect tenant middleware skips (parametric, vehicles, c…

### DIFF
--- a/src/IAMS.MultiTenancy/Middleware/TenantMiddleware.cs
+++ b/src/IAMS.MultiTenancy/Middleware/TenantMiddleware.cs
@@ -24,27 +24,6 @@ namespace IAMS.MultiTenancy.Middleware
 
         public async Task InvokeAsync(HttpContext context)
         {
-            // Skip tenant middleware for parametric/reference data endpoints (shared across tenants)
-            if (context.Request.Path.StartsWithSegments("/api/parametric"))
-            {
-                await _next(context);
-                return;
-            }
-
-            // Skip tenant middleware for vehicle data endpoints (shared across tenants)
-            if (context.Request.Path.StartsWithSegments("/api/vehicles"))
-            {
-                await _next(context);
-                return;
-            }
-
-            // Skip tenant middleware for currency endpoints (shared across tenants)
-            if (context.Request.Path.StartsWithSegments("/api/currencies"))
-            {
-                await _next(context);
-                return;
-            }
-
             try
             {
                 var tenantService = context.RequestServices.GetRequiredService<Interfaces.ITenantService>();


### PR DESCRIPTION
…urrencies)

All three skipped paths use IUnitOfWork → ApplicationDbContext which requires tenant context. Without it, they fall back to DefaultConnection (Initial Catalog=ApplicationDb) which doesn't exist.

This was the root cause of countries not loading (kktcCountry is null), which broke the nationality autocomplete entirely.

https://claude.ai/code/session_01UaY12DKcJhicKFCw49TkDE