### PR TITLE
Sync the traffic/kasko auto-paid import rule and make it a per-agency setting (#515)

### DIFF
--- a/src/IAMS.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/src/IAMS.Application/Extensions/ServiceCollectionExtensions.cs
@@ -77,6 +77,7 @@ namespace IAMS.Application.Extensions
             // Register Policy Import Services
             services.AddScoped<IExcelFileValidator, ExcelFileValidator>();
             services.AddScoped<IExcelPolicyParser, ExcelPolicyParser>();
+            services.AddScoped<IImportAutoPaymentService, ImportAutoPaymentService>();
 
             // Register Focused Policy Services (replaces bloated repository interface)
             services.AddScoped<IPolicyQueryService, PolicyQueryService>();

--- a/src/IAMS.Application/Features/Policies/Commands/ImportPolicies/ImportPoliciesCommandHandler.cs
+++ b/src/IAMS.Application/Features/Policies/Commands/ImportPolicies/ImportPoliciesCommandHandler.cs
@@ -21,6 +21,7 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
         private readonly IExcelPolicyParser _policyParser;
         private readonly IPolicyQueryService _policyQueryService;
         private readonly ICustomerCodeGenerator _customerCodeGenerator;
+        private readonly IImportAutoPaymentService _autoPaymentService;
         private readonly ILogger<ImportPoliciesCommandHandler> _logger;
 
         public ImportPoliciesCommandHandler(
@@ -29,6 +30,7 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
             IExcelPolicyParser policyParser,
             IPolicyQueryService policyQueryService,
             ICustomerCodeGenerator customerCodeGenerator,
+            IImportAutoPaymentService autoPaymentService,
             ILogger<ImportPoliciesCommandHandler> logger)
         {
             _unitOfWork = unitOfWork;
@@ -36,6 +38,7 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
             _policyParser = policyParser;
             _policyQueryService = policyQueryService;
             _customerCodeGenerator = customerCodeGenerator;
+            _autoPaymentService = autoPaymentService;
             _logger = logger;
         }
 
@@ -188,20 +191,18 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
             await _unitOfWork.Policies.AddAsync(policy);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
-            // Determine payment amount
-            // For traffic policies, automatically mark as fully paid (bakiye = 0)
-            bool isTrafficPolicy = policyType.Category?.Contains("Trafik", StringComparison.OrdinalIgnoreCase) == true ||
-                                   policyType.Category?.Contains("Traffic", StringComparison.OrdinalIgnoreCase) == true;
+            // Traffic-family policies (Trafik/Kasko variants) are auto-marked fully paid,
+            // unless the agency turned the AutoPayMandatoryPolicies setting off (see #515).
+            bool autoPay = await _autoPaymentService.ShouldAutoPayAsync(policyType, cancellationToken);
 
             decimal paymentAmount = 0;
-            if (isTrafficPolicy)
+            if (autoPay)
             {
-                // Traffic policies must be fully paid
                 paymentAmount = dto.PremiumAmount;
             }
             else if (dto.PaidAmount.HasValue && dto.PaidAmount.Value > 0)
             {
-                // Other policies use the provided paid amount
+                // Use the paid amount provided by the import source
                 paymentAmount = dto.PaidAmount.Value;
             }
 
@@ -216,7 +217,7 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
                     PaymentMethod = ParsePaymentMethod(dto.PaymentMethod),
                     Status = PaymentStatus.Completed,
                     CurrencyId = currency.Id,
-                    Notes = isTrafficPolicy ? "Auto-payment for traffic policy (bakiye = 0)" : "Initial payment from import",
+                    Notes = autoPay ? _autoPaymentService.AutoPaymentNote : "Initial payment from import",
                     CreatedBy = userId,
                     CreatedOn = DateTime.UtcNow,
                     ModifiedBy = userId,

--- a/src/IAMS.Application/Features/Policies/Commands/ImportPoliciesWithMapping/ImportPoliciesWithMappingCommandHandler.cs
+++ b/src/IAMS.Application/Features/Policies/Commands/ImportPoliciesWithMapping/ImportPoliciesWithMappingCommandHandler.cs
@@ -23,15 +23,18 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPoliciesWithMapping
     {
         private readonly IUnitOfWork _unitOfWork;
         private readonly ICustomerCodeGenerator _customerCodeGenerator;
+        private readonly IImportAutoPaymentService _autoPaymentService;
         private readonly ILogger<ImportPoliciesWithMappingCommandHandler> _logger;
 
         public ImportPoliciesWithMappingCommandHandler(
             IUnitOfWork unitOfWork,
             ICustomerCodeGenerator customerCodeGenerator,
+            IImportAutoPaymentService autoPaymentService,
             ILogger<ImportPoliciesWithMappingCommandHandler> logger)
         {
             _unitOfWork = unitOfWork;
             _customerCodeGenerator = customerCodeGenerator;
+            _autoPaymentService = autoPaymentService;
             _logger = logger;
         }
 
@@ -627,29 +630,19 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPoliciesWithMapping
             string userId,
             CancellationToken cancellationToken)
         {
-            // IMPORTANT: Traffic and KASKO policies MUST be fully paid by law (no outstanding amount allowed)
-            bool isTrafficPolicy = policyType.Name?.Contains("TRAFİK", StringComparison.OrdinalIgnoreCase) == true ||
-                                   policyType.Name?.Contains("TRAFIK", StringComparison.OrdinalIgnoreCase) == true ||
-                                   policyType.Name?.Contains("TRAFFIC", StringComparison.OrdinalIgnoreCase) == true ||
-                                   policyType.Name?.Contains("Trafik", StringComparison.OrdinalIgnoreCase) == true ||
-                                   policyType.Name?.Contains("Traffic", StringComparison.OrdinalIgnoreCase) == true ||
-                                   policyType.Name?.Contains("Trafik", StringComparison.OrdinalIgnoreCase) == true ||
-                                   policyType.Name?.Contains("Traffic", StringComparison.OrdinalIgnoreCase) == true;
-
-            bool isKaskoPolicy = policyType.Name?.Contains("KASKO", StringComparison.OrdinalIgnoreCase) == true;
-
-            bool requiresFullPayment = isTrafficPolicy || isKaskoPolicy;
+            // Traffic-family policies (Trafik/Kasko variants) are fully paid by law; the
+            // shared rule also honors the agency's AutoPayMandatoryPolicies setting (#515).
+            bool requiresFullPayment = await _autoPaymentService.ShouldAutoPayAsync(policyType, cancellationToken);
 
             decimal paymentAmount = 0;
             if (requiresFullPayment)
             {
-                // Traffic/KASKO policies: ALWAYS create full payment for premium amount
-                // This ensures zero outstanding balance as required by law
+                // Create full payment for the premium amount → zero outstanding balance
                 paymentAmount = policy.PremiumAmount; // Use actual policy premium, not DTO
 
                 _logger.LogInformation(
                     "Creating full payment for {PolicyType} policy {PolicyNumber}: {Amount}",
-                    isTrafficPolicy ? "TRAFFIC" : "KASKO",
+                    policyType.Name,
                     policy.PolicyNumber,
                     paymentAmount);
             }
@@ -670,7 +663,7 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPoliciesWithMapping
                     Status = PaymentStatus.Completed,
                     CurrencyId = currencyId,
                     Notes = requiresFullPayment
-                        ? (isTrafficPolicy ? "Trafik poliçesi - Tam ödeme (Yasal gereklilik)" : "Kasko poliçesi - Tam ödeme (Yasal gereklilik)")
+                        ? _autoPaymentService.AutoPaymentNote
                         : "Initial payment from import",
                     CreatedBy = userId,
                     CreatedOn = DateTime.UtcNow,
@@ -685,14 +678,14 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPoliciesWithMapping
                     "Created payment of {Amount} for policy {PolicyNumber} (Type: {PolicyType})",
                     paymentAmount,
                     policy.PolicyNumber,
-                    requiresFullPayment ? (isTrafficPolicy ? "Traffic" : "KASKO") : "Other");
+                    policyType.Name);
             }
             else if (requiresFullPayment)
             {
                 // This should never happen, but log as warning if it does
                 _logger.LogWarning(
                     "{PolicyType} policy {PolicyNumber} has zero premium amount - no payment created!",
-                    isTrafficPolicy ? "Traffic" : "KASKO",
+                    policyType.Name,
                     policy.PolicyNumber);
             }
         }

--- a/src/IAMS.Application/Features/Policies/Commands/SyncPoliciesFromMySql/SyncPoliciesFromMySqlCommandHandler.cs
+++ b/src/IAMS.Application/Features/Policies/Commands/SyncPoliciesFromMySql/SyncPoliciesFromMySqlCommandHandler.cs
@@ -16,17 +16,20 @@ namespace IAMS.Application.Features.Policies.Commands.SyncPoliciesFromMySql
         private readonly IUnitOfWork _unitOfWork;
         private readonly IMySqlPolicyImportService _mySqlImportService;
         private readonly ICustomerCodeGenerator _customerCodeGenerator;
+        private readonly IImportAutoPaymentService _autoPaymentService;
         private readonly ILogger<SyncPoliciesFromMySqlCommandHandler> _logger;
 
         public SyncPoliciesFromMySqlCommandHandler(
             IUnitOfWork unitOfWork,
             IMySqlPolicyImportService mySqlImportService,
             ICustomerCodeGenerator customerCodeGenerator,
+            IImportAutoPaymentService autoPaymentService,
             ILogger<SyncPoliciesFromMySqlCommandHandler> logger)
         {
             _unitOfWork = unitOfWork;
             _mySqlImportService = mySqlImportService;
             _customerCodeGenerator = customerCodeGenerator;
+            _autoPaymentService = autoPaymentService;
             _logger = logger;
         }
 
@@ -249,27 +252,14 @@ namespace IAMS.Application.Features.Policies.Commands.SyncPoliciesFromMySql
         }
 
         /// <summary>
-        /// Traffic (Trafik) and Kasko policies are legally required to be fully paid.
-        /// Automatically creates a completed payment record for these policy types.
+        /// Traffic-family policies (Trafik/Kasko variants) are legally required to be fully
+        /// paid; the shared rule also honors the agency's AutoPayMandatoryPolicies setting
+        /// (#515). Creates a completed payment record when the rule applies.
         /// </summary>
         private async Task CreateAutoPaymentIfRequiredAsync(
             Policy policy, PolicyType policyType, int currencyId, string userId, CancellationToken cancellationToken)
         {
-            bool isTrafficPolicy =
-                policyType.Code?.Contains("TRAFİK", StringComparison.OrdinalIgnoreCase) == true ||
-                policyType.Code?.Contains("TRAFIK", StringComparison.OrdinalIgnoreCase) == true ||
-                policyType.Code?.Contains("TRAFFIC", StringComparison.OrdinalIgnoreCase) == true ||
-                policyType.Name?.Contains("Trafik", StringComparison.OrdinalIgnoreCase) == true ||
-                policyType.Name?.Contains("Traffic", StringComparison.OrdinalIgnoreCase) == true ||
-                policyType.Category?.Contains("Trafik", StringComparison.OrdinalIgnoreCase) == true ||
-                policyType.Category?.Contains("Traffic", StringComparison.OrdinalIgnoreCase) == true;
-
-            bool isKaskoPolicy =
-                policyType.Code?.Contains("KASKO", StringComparison.OrdinalIgnoreCase) == true ||
-                policyType.Name?.Contains("Kasko", StringComparison.OrdinalIgnoreCase) == true ||
-                policyType.Category?.Contains("Kasko", StringComparison.OrdinalIgnoreCase) == true;
-
-            if (!isTrafficPolicy && !isKaskoPolicy)
+            if (!await _autoPaymentService.ShouldAutoPayAsync(policyType, cancellationToken))
                 return;
 
             if (policy.PremiumAmount <= 0)
@@ -283,9 +273,7 @@ namespace IAMS.Application.Features.Policies.Commands.SyncPoliciesFromMySql
                 PaymentMethod = PaymentMethod.BankTransfer,
                 Status = PaymentStatus.Completed,
                 CurrencyId = currencyId,
-                Notes = isTrafficPolicy
-                    ? "Trafik poliçesi - Tam ödeme (Yasal gereklilik)"
-                    : "Kasko poliçesi - Tam ödeme (Yasal gereklilik)",
+                Notes = _autoPaymentService.AutoPaymentNote,
                 CreatedBy = userId,
                 CreatedOn = DateTime.UtcNow,
                 ModifiedBy = userId,
@@ -296,7 +284,7 @@ namespace IAMS.Application.Features.Policies.Commands.SyncPoliciesFromMySql
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogDebug("Auto-created payment for {PolicyType} policy {PolicyNumber}: {Amount}",
-                isTrafficPolicy ? "traffic" : "kasko", policy.PolicyNumber, policy.PremiumAmount);
+                policyType.Name, policy.PolicyNumber, policy.PremiumAmount);
         }
 
         private async Task<Customer> GetOrCreateCustomerAsync(ImportPolicyDto dto, string userId)

--- a/src/IAMS.Application/Interfaces/Services/IImportAutoPaymentService.cs
+++ b/src/IAMS.Application/Interfaces/Services/IImportAutoPaymentService.cs
@@ -1,0 +1,30 @@
+using IAMS.Domain.Entities;
+
+namespace IAMS.Application.Interfaces.Services
+{
+    /// <summary>
+    /// Single home for the "traffic-family policies are fully paid at creation" import rule,
+    /// shared by all policy-import paths (Excel, preview/mapping, MySQL sync).
+    /// </summary>
+    public interface IImportAutoPaymentService
+    {
+        /// <summary>
+        /// Note text stored on auto-created payments so they remain recognizable.
+        /// </summary>
+        string AutoPaymentNote { get; }
+
+        /// <summary>
+        /// True when the policy type is in the traffic family covered by the law:
+        /// its code, name, or category contains Trafik/Traffic/Trafic or any Kasko
+        /// variant (Kasko, Yarım Kasko, Tam Kasko, ...), in any casing or spelling.
+        /// </summary>
+        bool RequiresFullPaymentByLaw(PolicyType policyType);
+
+        /// <summary>
+        /// Combines <see cref="RequiresFullPaymentByLaw"/> with the agency's
+        /// AutoPayMandatoryPolicies setting (default on). The setting is read once per
+        /// import run (per request scope), so a batch is never split between modes.
+        /// </summary>
+        Task<bool> ShouldAutoPayAsync(PolicyType policyType, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/IAMS.Application/Services/PolicyImport/ImportAutoPaymentService.cs
+++ b/src/IAMS.Application/Services/PolicyImport/ImportAutoPaymentService.cs
@@ -1,0 +1,75 @@
+using IAMS.Application.Interfaces.Services;
+using IAMS.Domain.Entities;
+using IAMS.Shared.DTOs.Settings;
+using IAMS.Shared.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace IAMS.Application.Services.PolicyImport
+{
+    public class ImportAutoPaymentService : IImportAutoPaymentService
+    {
+        // The law covers the whole traffic family: traffic itself in every spelling seen in
+        // source data (Trafik/Trafic/Traffic) and every Kasko variant (Kasko, Yarım Kasko,
+        // Tam Kasko, ...) — substring match on code, name, or category catches them all.
+        private static readonly string[] MandatoryMarkers = { "TRAFIK", "TRAFFIC", "TRAFIC", "KASKO" };
+
+        private readonly ITenantService _tenantService;
+        private readonly ILogger<ImportAutoPaymentService> _logger;
+
+        // One import run = one request scope, so caching here means the agency setting is
+        // read once per batch and a toggle mid-import cannot split a run between modes.
+        private bool? _autoPayEnabled;
+
+        public ImportAutoPaymentService(
+            ITenantService tenantService,
+            ILogger<ImportAutoPaymentService> logger)
+        {
+            _tenantService = tenantService;
+            _logger = logger;
+        }
+
+        public string AutoPaymentNote => "Trafik/Kasko poliçesi - Tam ödeme (Yasal gereklilik)";
+
+        public bool RequiresFullPaymentByLaw(PolicyType policyType)
+        {
+            return ContainsMandatoryMarker(policyType.Code) ||
+                   ContainsMandatoryMarker(policyType.Name) ||
+                   ContainsMandatoryMarker(policyType.Category);
+        }
+
+        public async Task<bool> ShouldAutoPayAsync(PolicyType policyType, CancellationToken cancellationToken = default)
+        {
+            if (!RequiresFullPaymentByLaw(policyType))
+            {
+                return false;
+            }
+
+            if (_autoPayEnabled == null)
+            {
+                var settings = await _tenantService.GetTenantSettingAsync<PolicyImportSettingsDto>(PolicyImportSettingsDto.SettingKey);
+                _autoPayEnabled = settings?.AutoPayMandatoryPolicies ?? true;
+
+                if (_autoPayEnabled == false)
+                {
+                    _logger.LogInformation("Auto full payment for traffic/kasko policies is disabled for this agency");
+                }
+            }
+
+            return _autoPayEnabled.Value;
+        }
+
+        private static bool ContainsMandatoryMarker(string? value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            // Fold the Turkish dotted/dotless İ/ı to plain I so TRAFİK, Trafik and trafık
+            // all match; ToUpperInvariant alone does not map U+0130/U+0131.
+            var normalized = value.ToUpperInvariant().Replace('İ', 'I').Replace('ı', 'I');
+
+            return MandatoryMarkers.Any(normalized.Contains);
+        }
+    }
+}

--- a/src/IAMS.Shared/DTOs/Settings/PolicyImportSettingsDto.cs
+++ b/src/IAMS.Shared/DTOs/Settings/PolicyImportSettingsDto.cs
@@ -1,0 +1,20 @@
+namespace IAMS.Shared.DTOs.Settings
+{
+    /// <summary>
+    /// Per-agency policy-import settings, stored in the tenant's own database
+    /// (TenantSettings table) under <see cref="SettingKey"/>.
+    /// </summary>
+    public class PolicyImportSettingsDto
+    {
+        public const string SettingKey = "policyImport";
+
+        /// <summary>
+        /// When true (default, the legally correct behavior), importing a traffic-family
+        /// policy (Trafik/Traffic or any Kasko variant) automatically creates a completed
+        /// payment for the full premium, so the policy carries no outstanding balance.
+        /// Agencies that track real payments for these policies can turn this off;
+        /// the change only affects imports started afterwards.
+        /// </summary>
+        public bool AutoPayMandatoryPolicies { get; set; } = true;
+    }
+}

--- a/src/IAMS.Web/Components/Pages/Settings/General/GeneralSettings.razor
+++ b/src/IAMS.Web/Components/Pages/Settings/General/GeneralSettings.razor
@@ -189,6 +189,28 @@
                     </MudCardContent>
                 </MudCard>
 
+                <!-- Policy Import Settings -->
+                <MudCard Class="mb-4">
+                    <MudCardHeader>
+                        <CardHeaderContent>
+                            <MudText Typo="Typo.h6">Poliçe İçe Aktarma</MudText>
+                        </CardHeaderContent>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudSwitch @bind-Value="policyImportModel.AutoPayMandatoryPolicies"
+                                   Color="Color.Primary"
+                                   Label="Trafik/Kasko poliçelerini içe aktarmada otomatik ödenmiş işaretle" />
+                        <MudText Typo="Typo.body2" Class="mud-text-secondary mt-2">
+                            Açıkken, içe aktarılan Trafik ve Kasko poliçeleri için prim tutarı kadar
+                            tamamlanmış bir ödeme kaydı otomatik oluşturulur (yasal gereklilik).
+                            Kapalıyken ödeme kaydı yalnızca içe aktarma kaynağındaki ödenen tutardan
+                            oluşturulur ve bakiyeler gerçek tahsilatı yansıtır. Değişiklik yalnızca
+                            bundan sonra başlatılan içe aktarmaları etkiler; mevcut ödeme kayıtları
+                            değiştirilmez.
+                        </MudText>
+                    </MudCardContent>
+                </MudCard>
+
                 <!-- Actions -->
                 <MudStack Row Justify="Justify.FlexEnd" Spacing="2">
                     <MudButton Variant="Variant.Outlined"
@@ -217,6 +239,7 @@
 
 @code {
     private GeneralSettingsDto settingsModel = new();
+    private PolicyImportSettingsDto policyImportModel = new();
     private bool isLoading = true;
 
     private List<BreadcrumbItem> _items = new List<BreadcrumbItem>
@@ -241,6 +264,9 @@
             {
                 settingsModel = settings;
             }
+
+            policyImportModel = await TenantService.GetTenantSettingAsync<PolicyImportSettingsDto>(PolicyImportSettingsDto.SettingKey)
+                                ?? new PolicyImportSettingsDto();
         }
         catch (Exception ex)
         {
@@ -258,6 +284,7 @@
         try
         {
             await TenantService.SetTenantSettingAsync("general", settingsModel);
+            await TenantService.SetTenantSettingAsync(PolicyImportSettingsDto.SettingKey, policyImportModel);
             Snackbar.Add("Ayarlar başarıyla kaydedildi", MudBlazor.Severity.Success);
         }
         catch (Exception ex)

--- a/tests/IAMS.UnitTests/Application/Services/PolicyImport/ImportAutoPaymentServiceTests.cs
+++ b/tests/IAMS.UnitTests/Application/Services/PolicyImport/ImportAutoPaymentServiceTests.cs
@@ -1,0 +1,109 @@
+using FluentAssertions;
+using IAMS.Application.Services.PolicyImport;
+using IAMS.Domain.Entities;
+using IAMS.Shared.DTOs.Settings;
+using IAMS.Shared.Interfaces;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace IAMS.UnitTests.Application.Services.PolicyImport;
+
+public class ImportAutoPaymentServiceTests
+{
+    private static ImportAutoPaymentService CreateService(PolicyImportSettingsDto? settings = null)
+    {
+        var tenantService = new Mock<ITenantService>();
+        tenantService
+            .Setup(s => s.GetTenantSettingAsync<PolicyImportSettingsDto>(PolicyImportSettingsDto.SettingKey))
+            .ReturnsAsync(settings);
+
+        return new ImportAutoPaymentService(tenantService.Object, NullLogger<ImportAutoPaymentService>.Instance);
+    }
+
+    private static PolicyType Type(string? name = null, string? code = null, string? category = null) =>
+        new() { Name = name!, Code = code!, Category = category! };
+
+    // The law covers the whole traffic family, in every spelling and casing that
+    // appears in source data — including the Turkish dotted İ.
+    [Theory]
+    [InlineData("Trafik Sigortası")]
+    [InlineData("TRAFİK")]
+    [InlineData("trafik")]
+    [InlineData("Traffic Insurance")]
+    [InlineData("Trafic")]
+    [InlineData("Kasko")]
+    [InlineData("KASKO")]
+    [InlineData("Tam Kasko")]
+    [InlineData("Yarım Kasko")]
+    [InlineData("Half Kasko")]
+    public void RequiresFullPaymentByLaw_TrafficFamilyNames_AreDetected(string name)
+    {
+        CreateService().RequiresFullPaymentByLaw(Type(name: name)).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("Konut Sigortası")]
+    [InlineData("Sağlık")]
+    [InlineData("DASK")]
+    [InlineData("")]
+    public void RequiresFullPaymentByLaw_OtherPolicyTypes_AreNot(string name)
+    {
+        CreateService().RequiresFullPaymentByLaw(Type(name: name)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void RequiresFullPaymentByLaw_MatchesOnCodeAndCategoryToo()
+    {
+        var service = CreateService();
+
+        service.RequiresFullPaymentByLaw(Type(name: "Motorlu Araç", code: "TRF-TRAFIK")).Should().BeTrue();
+        service.RequiresFullPaymentByLaw(Type(name: "Motorlu Araç", category: "Kasko Ürünleri")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ShouldAutoPay_DefaultsToOn_WhenNoSettingStored()
+    {
+        var service = CreateService(settings: null);
+
+        (await service.ShouldAutoPayAsync(Type(name: "Trafik"))).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ShouldAutoPay_RespectsAgencyOptOut()
+    {
+        var service = CreateService(new PolicyImportSettingsDto { AutoPayMandatoryPolicies = false });
+
+        (await service.ShouldAutoPayAsync(Type(name: "Trafik"))).Should().BeFalse();
+        (await service.ShouldAutoPayAsync(Type(name: "Tam Kasko"))).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ShouldAutoPay_NeverAppliesToNonTrafficPolicies()
+    {
+        var service = CreateService(new PolicyImportSettingsDto { AutoPayMandatoryPolicies = true });
+
+        (await service.ShouldAutoPayAsync(Type(name: "Konut"))).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ShouldAutoPay_ReadsTheSettingOncePerServiceScope()
+    {
+        var tenantService = new Mock<ITenantService>();
+        tenantService
+            .Setup(s => s.GetTenantSettingAsync<PolicyImportSettingsDto>(PolicyImportSettingsDto.SettingKey))
+            .ReturnsAsync(new PolicyImportSettingsDto { AutoPayMandatoryPolicies = true });
+
+        var service = new ImportAutoPaymentService(tenantService.Object, NullLogger<ImportAutoPaymentService>.Instance);
+
+        await service.ShouldAutoPayAsync(Type(name: "Trafik"));
+        await service.ShouldAutoPayAsync(Type(name: "Kasko"));
+        await service.ShouldAutoPayAsync(Type(name: "Trafik"));
+
+        // One import batch = one service scope: the agency setting is read a single time,
+        // so toggling it mid-import cannot split a running batch between modes.
+        tenantService.Verify(
+            s => s.GetTenantSettingAsync<PolicyImportSettingsDto>(PolicyImportSettingsDto.SettingKey),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
Closes #515. Also removes one chunk of the triplicated import logic from #508.

> Stacked on `fix/security-503-507` (PR #514) — this PR's own changes are the two commits `680ad5c` and `4f6baa7`. Merge #514 first.

## 1. Rule synced across all import paths (first commit)
The "traffic-family policies are fully paid at creation, as per law" rule was copy-pasted into all three import handlers with **different** scopes: the legacy Excel import auto-paid traffic only (matching just `Category`), while the preview/mapping and MySQL paths also covered Kasko, each matching different fields.

Now a single `ImportAutoPaymentService` owns the rule:
- Detection covers the whole family — **Trafik / Traffic / Trafic and every Kasko variant** (Kasko, Yarım Kasko, Tam Kasko, …) — matched on `Code`, `Name`, and `Category`, with Turkish dotted **İ/ı folding** so `TRAFİK`, `Trafik`, `trafik` all match.
- All three handlers (legacy Excel, preview/mapping, MySQL sync) delegate to it and write the same recognizable payment note: `Trafik/Kasko poliçesi - Tam ödeme (Yasal gereklilik)`.

## 2. Per-agency switch (second commit)
- **Settings > General → "Poliçe İçe Aktarma"**: a switch controlling whether import auto-creates the full-premium payment for traffic/kasko policies.
- Stored in the agency's own database (`TenantSettings`, key `policyImport`) via the existing tenant-settings mechanism; **default ON** = current legal behavior, so nothing changes for existing agencies.
- The setting is read **once per import batch** (per request scope) — flipping it mid-import cannot split a running batch between modes; it takes effect from the next import.
- **Not retroactive** in either direction: toggling never creates or deletes historical payments (per discussion, no cleanup tool — agencies adjust old records manually if they toggle back and forth).
- With the switch OFF, payments come only from the import source's paid amount (Excel `PaidAmount`; the MySQL sync creates none), so outstanding balances reflect real collections.

## Tests
195 unit + 31 integration tests pass. New unit tests cover the detection variants (incl. Turkish İ, Tam/Yarım Kasko), default-on when no setting is stored, the agency opt-out, non-traffic types never auto-paying, and the read-once-per-batch guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)