### PR TITLE
Show total premium (toplam prim) per currency on the Cari Kart list (#517)

### DIFF
--- a/src/IAMS.Application/Features/Customers/Queries/GetCustomersWithBalances/GetCustomersWithBalancesQueryHandler.cs
+++ b/src/IAMS.Application/Features/Customers/Queries/GetCustomersWithBalances/GetCustomersWithBalancesQueryHandler.cs
@@ -90,8 +90,10 @@ namespace IAMS.Application.Features.Customers.Queries.GetCustomersWithBalances
 
                     var balance = group.TotalPremium - totalPaid;
 
-                    // Only include if there's a non-zero balance
-                    if (balance != 0)
+                    // Include every customer/currency with activity: rows with an outstanding
+                    // balance AND fully-paid rows, so the UI can show premium totals (#517).
+                    // Consumers that only care about debt filter on Balance != 0 themselves.
+                    if (balance != 0 || group.TotalPremium != 0)
                     {
                         result.Add(new CustomerWithBalanceDto
                         {

--- a/src/IAMS.Web/Components/Pages/Customers/CustomerList.razor
+++ b/src/IAMS.Web/Components/Pages/Customers/CustomerList.razor
@@ -113,6 +113,13 @@
                                 </MudText>
                             </CellTemplate>
                         </TemplateColumn>
+                        <TemplateColumn Title="Toplam Prim" Sortable="false">
+                            <CellTemplate>
+                                <MudText Typo="Typo.body1" Style="font-size: 1rem; font-weight: 500;">
+                                    @GetCustomerPremium(context.Item.Id)
+                                </MudText>
+                            </CellTemplate>
+                        </TemplateColumn>
                         <TemplateColumn Title="Bakiye" Sortable="false">
                             <CellTemplate>
                                 @{
@@ -165,6 +172,23 @@
                                 else
                                 {
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">Poliçe yok</MudText>
+                                }
+                            </CellTemplate>
+                        </TemplateColumn>
+                        <TemplateColumn Title="Toplam Prim" Sortable="false">
+                            <CellTemplate>
+                                @{
+                                    var premium = GetCustomerPremium(context.Item.Id);
+                                }
+                                @if (premium != "-")
+                                {
+                                    <MudChip T="String" Size="Size.Small" Color="Color.Info" Icon="@Icons.Material.Filled.RequestQuote">
+                                        @premium
+                                    </MudChip>
+                                }
+                                else
+                                {
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">-</MudText>
                                 }
                             </CellTemplate>
                         </TemplateColumn>
@@ -300,6 +324,7 @@
 @code {
     private List<CustomerDto> customers = new();
     private Dictionary<int, Dictionary<string, decimal>> customerBalances = new();
+    private Dictionary<int, Dictionary<string, decimal>> customerPremiums = new();
     private List<CurrencyDto> currencies = new();
     private bool loading = true;
     private ListViewMode viewMode = ListViewMode.Simple;
@@ -429,6 +454,7 @@
             if (balancesResult.IsSuccess && balancesResult.Data != null)
             {
                 customerBalances.Clear();
+                customerPremiums.Clear();
                 foreach (var item in balancesResult.Data)
                 {
                     if (!customerBalances.ContainsKey(item.Id))
@@ -436,6 +462,12 @@
                         customerBalances[item.Id] = new Dictionary<string, decimal>();
                     }
                     customerBalances[item.Id][item.Currency] = item.Balance;
+
+                    if (!customerPremiums.ContainsKey(item.Id))
+                    {
+                        customerPremiums[item.Id] = new Dictionary<string, decimal>();
+                    }
+                    customerPremiums[item.Id][item.Currency] = item.TotalPremium;
                 }
             }
         }
@@ -584,5 +616,20 @@
             .ToList();
 
         return balances.Any() ? string.Join(" | ", balances) : "-";
+    }
+
+    private string GetCustomerPremium(int customerId)
+    {
+        if (!customerPremiums.ContainsKey(customerId) || !customerPremiums[customerId].Any())
+        {
+            return "-";
+        }
+
+        var premiums = customerPremiums[customerId]
+            .Where(p => p.Value != 0)
+            .Select(p => $"{p.Value:N2} {p.Key}")
+            .ToList();
+
+        return premiums.Any() ? string.Join(" | ", premiums) : "-";
     }
 }

--- a/src/IAMS.Web/Components/Pages/Policies/PolicyDetails.razor
+++ b/src/IAMS.Web/Components/Pages/Policies/PolicyDetails.razor
@@ -869,7 +869,9 @@ else
             if (balancesResult.IsSuccess && balancesResult.Data != null)
             {
                 customerBalanceByCurrency.Clear();
-                var customerBalances = balancesResult.Data.Where(b => b.Id == policy.CustomerId);
+                // The endpoint also returns fully-paid customer/currency rows (for premium
+                // totals on the customer list); only outstanding balances matter here.
+                var customerBalances = balancesResult.Data.Where(b => b.Id == policy.CustomerId && b.Balance != 0);
                 foreach (var balance in customerBalances)
                 {
                     customerBalanceByCurrency[balance.Currency] = balance.Balance;


### PR DESCRIPTION
Closes #517.

> Stacked on `fix/515-optional-traffic-auto-payment` (PR #516); this PR's own change is the single top commit.

Agency users asked for the customer's total premium next to the existing bakiye on the Cari Kart list, broken down per currency.

- **Backend**: `GetCustomersWithBalancesQueryHandler` already computed `TotalPremium`/`TotalPaid` per customer per currency but returned only rows with a non-zero balance — fully-paid customers had no row at all. It now also returns zero-balance rows that have premium activity. Same `CustomerWithBalanceDto`, so no API contract change.
- **Customer list**: new **"Toplam Prim"** column in both the simple and the detailed view, formatted per currency (`12.345,00 TRY | 500,00 USD`), neutral styling next to the red bakiye. Bakiye behavior is unchanged — zero balances still render as "no balance" (dash / green check).
- **PolicyDetails**: the "Müşteri Toplam Bakiyesi" banner reuses the same endpoint; it now filters out the newly returned zero-balance rows so its display is unchanged.

Build clean; 195 unit + 31 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)