### PR TITLE
Show total premium per currency on the Cari Kart list, with SQL-side aggregation (#517)

### DIFF
--- a/src/IAMS.Api/Controllers/CustomersController.cs
+++ b/src/IAMS.Api/Controllers/CustomersController.cs
@@ -66,9 +66,9 @@ namespace IAMS.Api.Controllers
         /// Get all customers with their balances per currency
         /// </summary>
         [HttpGet("with-balances")]
-        public async Task<ActionResult<Result<List<CustomerWithBalanceDto>>>> GetCustomersWithBalances()
+        public async Task<ActionResult<Result<List<CustomerWithBalanceDto>>>> GetCustomersWithBalances([FromQuery] int? customerId = null)
         {
-            var query = new GetCustomersWithBalancesQuery();
+            var query = new GetCustomersWithBalancesQuery(customerId);
             var result = await _mediator.Send(query);
 
             if (!result.IsSuccess)

--- a/src/IAMS.Application/Features/Customers/Queries/GetCustomersWithBalances/GetCustomersWithBalancesQuery.cs
+++ b/src/IAMS.Application/Features/Customers/Queries/GetCustomersWithBalances/GetCustomersWithBalancesQuery.cs
@@ -6,5 +6,15 @@ namespace IAMS.Application.Features.Customers.Queries.GetCustomersWithBalances
 {
     public class GetCustomersWithBalancesQuery : IRequest<Result<List<CustomerWithBalanceDto>>>
     {
+        /// <summary>
+        /// When set, restricts the aggregation to a single customer (e.g. the policy
+        /// details page only needs that customer's balances).
+        /// </summary>
+        public int? CustomerId { get; set; }
+
+        public GetCustomersWithBalancesQuery(int? customerId = null)
+        {
+            CustomerId = customerId;
+        }
     }
 }

--- a/src/IAMS.Application/Features/Customers/Queries/GetCustomersWithBalances/GetCustomersWithBalancesQueryHandler.cs
+++ b/src/IAMS.Application/Features/Customers/Queries/GetCustomersWithBalances/GetCustomersWithBalancesQueryHandler.cs
@@ -25,93 +25,94 @@ namespace IAMS.Application.Features.Customers.Queries.GetCustomersWithBalances
         {
             try
             {
-                _logger.LogInformation("Getting customers with balances per currency");
+                _logger.LogInformation("Getting customers with balances per currency (customerId: {CustomerId})", request.CustomerId);
 
-                // Get all policies with their related data
-                var policies = await _unitOfWork.Policies.AsQueryable()
+                // Premium totals aggregated in the database, per customer per currency.
+                var premiumTotals = await _unitOfWork.Policies.AsQueryable()
                     .Where(p => !p.IsDeleted)
-                    .Include(p => p.Customer)
-                    .Include(p => p.Currency)
-                    .Select(p => new
-                    {
-                        p.Id,
-                        p.CustomerId,
-                        CustomerCode = p.Customer.CustomerCode,
-                        FirstName = p.Customer.FirstName,
-                        LastName = p.Customer.LastName,
-                        Email = p.Customer.Email,
-                        MobilePhoneNumber = p.Customer.MobilePhoneNumber,
-                        Status = p.Customer.Status,
-                        CreatedOn = p.Customer.CreatedOn,
-                        CurrencyCode = p.Currency.Code,
-                        p.PremiumAmount,
-                        PolicyStatus = p.Status
-                    })
-                    .ToListAsync(cancellationToken);
-
-                // Get all payments
-                var payments = await _unitOfWork.PolicyPayments.AsQueryable()
-                    .Where(p => !p.IsDeleted)
-                    .Select(p => new
-                    {
-                        p.PolicyId,
-                        p.Amount
-                    })
-                    .ToListAsync(cancellationToken);
-
-                // Group by customer and currency
-                var customerCurrencyGroups = policies
-                    .GroupBy(p => new { p.CustomerId, p.CurrencyCode })
+                    .Where(p => request.CustomerId == null || p.CustomerId == request.CustomerId)
+                    .GroupBy(p => new { p.CustomerId, CurrencyCode = p.Currency.Code })
                     .Select(g => new
                     {
                         g.Key.CustomerId,
                         g.Key.CurrencyCode,
-                        CustomerCode = g.First().CustomerCode,
-                        FirstName = g.First().FirstName,
-                        LastName = g.First().LastName,
-                        Email = g.First().Email,
-                        MobilePhoneNumber = g.First().MobilePhoneNumber,
-                        Status = g.First().Status,
-                        CreatedOn = g.First().CreatedOn,
                         TotalPremium = g.Sum(p => p.PremiumAmount),
-                        ActivePolicyCount = g.Count(p => p.PolicyStatus == PolicyStatus.Active),
-                        PolicyIds = g.Select(p => p.Id).ToList()
+                        ActivePolicyCount = g.Sum(p => p.Status == PolicyStatus.Active ? 1 : 0)
                     })
-                    .ToList();
+                    .ToListAsync(cancellationToken);
 
-                // Calculate balances
+                // Paid totals aggregated in the database, grouped by the policy's currency
+                // (payments are recorded in the policy currency).
+                var paidTotals = await _unitOfWork.PolicyPayments.AsQueryable()
+                    .Where(pp => !pp.IsDeleted && !pp.Policy.IsDeleted)
+                    .Where(pp => request.CustomerId == null || pp.Policy.CustomerId == request.CustomerId)
+                    .GroupBy(pp => new { pp.Policy.CustomerId, CurrencyCode = pp.Policy.Currency.Code })
+                    .Select(g => new
+                    {
+                        g.Key.CustomerId,
+                        g.Key.CurrencyCode,
+                        TotalPaid = g.Sum(pp => pp.Amount)
+                    })
+                    .ToListAsync(cancellationToken);
+
+                var paidLookup = paidTotals.ToDictionary(x => (x.CustomerId, x.CurrencyCode), x => x.TotalPaid);
+
+                // Contact/identity fields for the customers that have policies.
+                var customers = await _unitOfWork.Customers.AsQueryable()
+                    .Where(c => request.CustomerId == null || c.Id == request.CustomerId)
+                    .Where(c => c.Policies.Any(p => !p.IsDeleted))
+                    .Select(c => new
+                    {
+                        c.Id,
+                        c.CustomerCode,
+                        c.FirstName,
+                        c.LastName,
+                        c.Email,
+                        c.MobilePhoneNumber,
+                        c.Status,
+                        c.CreatedOn
+                    })
+                    .ToListAsync(cancellationToken);
+
+                var customerLookup = customers.ToDictionary(c => c.Id);
+
+                // Every payment belongs to a policy, so premiumTotals covers all
+                // customer/currency combinations with any activity.
                 var result = new List<CustomerWithBalanceDto>();
-
-                foreach (var group in customerCurrencyGroups)
+                foreach (var group in premiumTotals)
                 {
-                    var totalPaid = payments
-                        .Where(p => group.PolicyIds.Contains(p.PolicyId))
-                        .Sum(p => p.Amount);
-
+                    var totalPaid = paidLookup.TryGetValue((group.CustomerId, group.CurrencyCode), out var paid) ? paid : 0m;
                     var balance = group.TotalPremium - totalPaid;
 
-                    // Include every customer/currency with activity: rows with an outstanding
-                    // balance AND fully-paid rows, so the UI can show premium totals (#517).
-                    // Consumers that only care about debt filter on Balance != 0 themselves.
-                    if (balance != 0 || group.TotalPremium != 0)
+                    // Include rows with an outstanding balance AND fully-paid rows, so the
+                    // UI can show premium totals (#517). Consumers that only care about
+                    // debt filter on Balance != 0 themselves.
+                    if (balance == 0 && group.TotalPremium == 0)
                     {
-                        result.Add(new CustomerWithBalanceDto
-                        {
-                            Id = group.CustomerId,
-                            CustomerCode = group.CustomerCode,
-                            FirstName = group.FirstName,
-                            LastName = group.LastName,
-                            Email = group.Email,
-                            MobilePhoneNumber = group.MobilePhoneNumber,
-                            Status = group.Status,
-                            CreatedOn = group.CreatedOn,
-                            ActivePolicyCount = group.ActivePolicyCount,
-                            Currency = group.CurrencyCode,
-                            Balance = balance,
-                            TotalPremium = group.TotalPremium,
-                            TotalPaid = totalPaid
-                        });
+                        continue;
                     }
+
+                    if (!customerLookup.TryGetValue(group.CustomerId, out var customer))
+                    {
+                        continue;
+                    }
+
+                    result.Add(new CustomerWithBalanceDto
+                    {
+                        Id = group.CustomerId,
+                        CustomerCode = customer.CustomerCode,
+                        FirstName = customer.FirstName,
+                        LastName = customer.LastName,
+                        Email = customer.Email,
+                        MobilePhoneNumber = customer.MobilePhoneNumber,
+                        Status = customer.Status,
+                        CreatedOn = customer.CreatedOn,
+                        ActivePolicyCount = group.ActivePolicyCount,
+                        Currency = group.CurrencyCode,
+                        Balance = balance,
+                        TotalPremium = group.TotalPremium,
+                        TotalPaid = totalPaid
+                    });
                 }
 
                 _logger.LogInformation("Found {Count} customer-currency combinations with balances", result.Count);

--- a/src/IAMS.Application/Features/Customers/Queries/GetCustomersWithBalances/GetCustomersWithBalancesQueryHandler.cs
+++ b/src/IAMS.Application/Features/Customers/Queries/GetCustomersWithBalances/GetCustomersWithBalancesQueryHandler.cs
@@ -90,8 +90,10 @@ namespace IAMS.Application.Features.Customers.Queries.GetCustomersWithBalances
 
                     var balance = group.TotalPremium - totalPaid;
 
-                    // Only include if there's a non-zero balance
-                    if (balance != 0)
+                    // Include every customer/currency with activity: rows with an outstanding
+                    // balance AND fully-paid rows, so the UI can show premium totals (#517).
+                    // Consumers that only care about debt filter on Balance != 0 themselves.
+                    if (balance != 0 || group.TotalPremium != 0)
                     {
                         result.Add(new CustomerWithBalanceDto
                         {

--- a/src/IAMS.Web/Components/Pages/Customers/CustomerList.razor
+++ b/src/IAMS.Web/Components/Pages/Customers/CustomerList.razor
@@ -113,6 +113,13 @@
                                 </MudText>
                             </CellTemplate>
                         </TemplateColumn>
+                        <TemplateColumn Title="Toplam Prim" Sortable="false">
+                            <CellTemplate>
+                                <MudText Typo="Typo.body1" Style="font-size: 1rem; font-weight: 500;">
+                                    @GetCustomerPremium(context.Item.Id)
+                                </MudText>
+                            </CellTemplate>
+                        </TemplateColumn>
                         <TemplateColumn Title="Bakiye" Sortable="false">
                             <CellTemplate>
                                 @{
@@ -165,6 +172,23 @@
                                 else
                                 {
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">Poliçe yok</MudText>
+                                }
+                            </CellTemplate>
+                        </TemplateColumn>
+                        <TemplateColumn Title="Toplam Prim" Sortable="false">
+                            <CellTemplate>
+                                @{
+                                    var premium = GetCustomerPremium(context.Item.Id);
+                                }
+                                @if (premium != "-")
+                                {
+                                    <MudChip T="String" Size="Size.Small" Color="Color.Info" Icon="@Icons.Material.Filled.RequestQuote">
+                                        @premium
+                                    </MudChip>
+                                }
+                                else
+                                {
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">-</MudText>
                                 }
                             </CellTemplate>
                         </TemplateColumn>
@@ -300,6 +324,7 @@
 @code {
     private List<CustomerDto> customers = new();
     private Dictionary<int, Dictionary<string, decimal>> customerBalances = new();
+    private Dictionary<int, Dictionary<string, decimal>> customerPremiums = new();
     private List<CurrencyDto> currencies = new();
     private bool loading = true;
     private ListViewMode viewMode = ListViewMode.Simple;
@@ -429,6 +454,7 @@
             if (balancesResult.IsSuccess && balancesResult.Data != null)
             {
                 customerBalances.Clear();
+                customerPremiums.Clear();
                 foreach (var item in balancesResult.Data)
                 {
                     if (!customerBalances.ContainsKey(item.Id))
@@ -436,6 +462,12 @@
                         customerBalances[item.Id] = new Dictionary<string, decimal>();
                     }
                     customerBalances[item.Id][item.Currency] = item.Balance;
+
+                    if (!customerPremiums.ContainsKey(item.Id))
+                    {
+                        customerPremiums[item.Id] = new Dictionary<string, decimal>();
+                    }
+                    customerPremiums[item.Id][item.Currency] = item.TotalPremium;
                 }
             }
         }
@@ -584,5 +616,20 @@
             .ToList();
 
         return balances.Any() ? string.Join(" | ", balances) : "-";
+    }
+
+    private string GetCustomerPremium(int customerId)
+    {
+        if (!customerPremiums.ContainsKey(customerId) || !customerPremiums[customerId].Any())
+        {
+            return "-";
+        }
+
+        var premiums = customerPremiums[customerId]
+            .Where(p => p.Value != 0)
+            .Select(p => $"{p.Value:N2} {p.Key}")
+            .ToList();
+
+        return premiums.Any() ? string.Join(" | ", premiums) : "-";
     }
 }

--- a/src/IAMS.Web/Components/Pages/Policies/PolicyDetails.razor
+++ b/src/IAMS.Web/Components/Pages/Policies/PolicyDetails.razor
@@ -865,7 +865,7 @@ else
         {
             if (policy?.CustomerId == null) return;
 
-            var balancesResult = await CustomersApi.GetCustomersWithBalancesAsync();
+            var balancesResult = await CustomersApi.GetCustomersWithBalancesAsync(policy.CustomerId);
             if (balancesResult.IsSuccess && balancesResult.Data != null)
             {
                 customerBalanceByCurrency.Clear();

--- a/src/IAMS.Web/Components/Pages/Policies/PolicyDetails.razor
+++ b/src/IAMS.Web/Components/Pages/Policies/PolicyDetails.razor
@@ -869,7 +869,9 @@ else
             if (balancesResult.IsSuccess && balancesResult.Data != null)
             {
                 customerBalanceByCurrency.Clear();
-                var customerBalances = balancesResult.Data.Where(b => b.Id == policy.CustomerId);
+                // The endpoint also returns fully-paid customer/currency rows (for premium
+                // totals on the customer list); only outstanding balances matter here.
+                var customerBalances = balancesResult.Data.Where(b => b.Id == policy.CustomerId && b.Balance != 0);
                 foreach (var balance in customerBalances)
                 {
                     customerBalanceByCurrency[balance.Currency] = balance.Balance;

--- a/src/IAMS.Web/Services/ApiClient/CustomersApiClient.cs
+++ b/src/IAMS.Web/Services/ApiClient/CustomersApiClient.cs
@@ -21,7 +21,7 @@ namespace IAMS.Web.Services.ApiClient
         Task<Result<List<CustomerPaymentDto>>> GetCustomerPaymentsAsync(int id);
         Task<Result<CustomerPaymentDto>> CreateCustomerPaymentAsync(int id, CreateCustomerPaymentDto paymentDto);
         Task<Result<CustomerMultiCurrencyStatementDto>> GetCustomerStatementAsync(int id, DateTime? startDate, DateTime? endDate, int? currencyId);
-        Task<Result<List<CustomerWithBalanceDto>>> GetCustomersWithBalancesAsync();
+        Task<Result<List<CustomerWithBalanceDto>>> GetCustomersWithBalancesAsync(int? customerId = null);
     }
 
     public class CustomersApiClient : BaseApiClient, ICustomersApiClient
@@ -107,9 +107,10 @@ namespace IAMS.Web.Services.ApiClient
             return await GetAsync<CustomerMultiCurrencyStatementDto>($"api/customers/{id}/statement{query}");
         }
 
-        public async Task<Result<List<CustomerWithBalanceDto>>> GetCustomersWithBalancesAsync()
+        public async Task<Result<List<CustomerWithBalanceDto>>> GetCustomersWithBalancesAsync(int? customerId = null)
         {
-            return await GetAsync<List<CustomerWithBalanceDto>>("api/customers/with-balances");
+            var query = customerId.HasValue ? $"?customerId={customerId.Value}" : string.Empty;
+            return await GetAsync<List<CustomerWithBalanceDto>>($"api/customers/with-balances{query}");
         }
     }
 }

--- a/tests/IAMS.IntegrationTests/Controllers/CustomersWithBalancesTests.cs
+++ b/tests/IAMS.IntegrationTests/Controllers/CustomersWithBalancesTests.cs
@@ -1,0 +1,144 @@
+using System.Net.Http.Json;
+using FluentAssertions;
+using IAMS.Domain.Entities;
+using IAMS.Domain.Enums;
+using IAMS.IntegrationTests.Fixtures;
+using IAMS.Persistence.Contexts;
+using IAMS.Shared.DTOs.Customer;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace IAMS.IntegrationTests.API.Controllers;
+
+/// <summary>
+/// Covers the SQL-aggregated customers-with-balances endpoint (#517):
+/// per-currency premium/paid totals, inclusion of fully-paid customers,
+/// and the optional customerId filter.
+/// </summary>
+public class CustomersWithBalancesTests : IClassFixture<TestWebApplicationFactory<Program>>
+{
+    private const string Tenant = "test-agency-1";
+    private readonly TestWebApplicationFactory<Program> _factory;
+
+    public CustomersWithBalancesTests(TestWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        SeedPoliciesAndPayments();
+    }
+
+    private void SeedPoliciesAndPayments()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var tenantAccessor = scope.ServiceProvider.GetRequiredService<IAMS.MultiTenancy.Interfaces.ITenantContextAccessor>();
+        tenantAccessor.TenantContext = new IAMS.MultiTenancy.Models.TenantContext(
+            new IAMS.MultiTenancy.Models.Tenant { Identifier = Tenant });
+
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        if (db.Policies.Any())
+        {
+            return; // already seeded by an earlier test in this class
+        }
+
+        // The context seeds currencies itself; reuse them (create only if missing).
+        var tryCurrency = db.Currencies.FirstOrDefault(c => c.Code == "TRY")
+            ?? db.Currencies.Add(new Currency { Code = "TRY", Name = "Turkish Lira" }).Entity;
+        var usdCurrency = db.Currencies.FirstOrDefault(c => c.Code == "USD")
+            ?? db.Currencies.Add(new Currency { Code = "USD", Name = "US Dollar" }).Entity;
+        db.SaveChanges();
+
+        // Customer 1 (Ahmet, seeded by DatabaseSeeder): two TRY policies,
+        // 1000 with 400 paid + 500 fully paid → premium 1500, paid 900, balance 600.
+        var p1 = NewPolicy(id: 101, customerId: 1, currencyId: tryCurrency.Id, premium: 1000m);
+        var p2 = NewPolicy(id: 102, customerId: 1, currencyId: tryCurrency.Id, premium: 500m);
+        // Customer 2 (Fatma): one USD policy, fully paid → premium 200, balance 0.
+        var p3 = NewPolicy(id: 103, customerId: 2, currencyId: usdCurrency.Id, premium: 200m);
+        db.Policies.AddRange(p1, p2, p3);
+
+        db.PolicyPayments.AddRange(
+            NewPayment(id: 201, policyId: 101, currencyId: tryCurrency.Id, amount: 400m),
+            NewPayment(id: 202, policyId: 102, currencyId: tryCurrency.Id, amount: 500m),
+            NewPayment(id: 203, policyId: 103, currencyId: usdCurrency.Id, amount: 200m));
+
+        db.SaveChanges();
+    }
+
+    private static Policy NewPolicy(int id, int customerId, int currencyId, decimal premium) => new()
+    {
+        Id = id,
+        PolicyNumber = $"POL-{id}",
+        CustomerId = customerId,
+        CurrencyId = currencyId,
+        InsuranceCompanyId = 1,
+        PolicyTypeId = 1,
+        PremiumAmount = premium,
+        Status = PolicyStatus.Active,
+        StartDate = DateTime.Today,
+        EndDate = DateTime.Today.AddYears(1),
+        CreatedOn = DateTime.UtcNow
+    };
+
+    private static PolicyPayment NewPayment(int id, int policyId, int currencyId, decimal amount) => new()
+    {
+        Id = id,
+        PolicyId = policyId,
+        CurrencyId = currencyId,
+        Amount = amount,
+        PaymentDate = DateTime.Today,
+        Status = PaymentStatus.Completed,
+        CreatedOn = DateTime.UtcNow
+    };
+
+    private HttpClient CreateClient()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Tenant-ID", Tenant);
+        return client;
+    }
+
+    [Fact]
+    public async Task ReturnsPremiumAndBalanceTotals_PerCustomerAndCurrency()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetFromJsonAsync<IAMS.Shared.Models.Result<List<CustomerWithBalanceDto>>>(
+            "/api/customers/with-balances");
+
+        response!.IsSuccess.Should().BeTrue();
+        var rows = response.Data!;
+
+        var ahmetTry = rows.Single(r => r.Id == 1 && r.Currency == "TRY");
+        ahmetTry.TotalPremium.Should().Be(1500m);
+        ahmetTry.TotalPaid.Should().Be(900m);
+        ahmetTry.Balance.Should().Be(600m);
+        ahmetTry.ActivePolicyCount.Should().Be(2);
+        ahmetTry.FirstName.Should().Be("Ahmet");
+    }
+
+    [Fact]
+    public async Task IncludesFullyPaidCustomers_WithZeroBalance()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetFromJsonAsync<IAMS.Shared.Models.Result<List<CustomerWithBalanceDto>>>(
+            "/api/customers/with-balances");
+
+        // Fatma's USD policy is fully paid — before #517 she was omitted entirely;
+        // now her premium total must be available with a zero balance.
+        var fatmaUsd = response!.Data!.Single(r => r.Id == 2 && r.Currency == "USD");
+        fatmaUsd.TotalPremium.Should().Be(200m);
+        fatmaUsd.Balance.Should().Be(0m);
+    }
+
+    [Fact]
+    public async Task CustomerIdFilter_ReturnsOnlyThatCustomer()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetFromJsonAsync<IAMS.Shared.Models.Result<List<CustomerWithBalanceDto>>>(
+            "/api/customers/with-balances?customerId=2");
+
+        response!.IsSuccess.Should().BeTrue();
+        response.Data.Should().OnlyContain(r => r.Id == 2);
+        response.Data.Should().ContainSingle(r => r.Currency == "USD");
+    }
+}


### PR DESCRIPTION
Closes #517. Re-targeted to `master`: the approved PR #518 merged into the `fix/515-optional-traffic-auto-payment` stack branch *after* that branch had already gone to master (via #516 → #519), so its two commits never landed on master. This PR brings exactly those two commits; the diff against master is identical to what was approved in #518.

## Total premium on the customer list (`fcf4b85`)
- The balances endpoint now also returns fully-paid customer/currency rows (it previously dropped them, so fully-paid customers had no premium data). Same `CustomerWithBalanceDto` — no API contract change.
- Cari Kart list gains a **"Toplam Prim"** column, per currency (`12.345,00 TRY | 500,00 USD`), in both the simple and detailed views. Bakiye behavior unchanged — zero balances still show as "no balance".

## SQL-side aggregation (`d52c8ac`)
- The handler previously loaded **every policy and every payment into memory** and matched payments to customer groups with per-group `Contains` scans. It now runs two `GROUP BY` queries (premium totals per customer+currency; paid totals grouped by the policy's currency) plus one slim customer-info query. Identical results, a fraction of the data transferred.
- New optional `customerId` filter on the endpoint; the policy details page uses it instead of downloading the whole agency's balance list for one banner.

## Tests
3 new integration tests (per-currency totals; fully-paid customers included with zero balance; the `customerId` filter). 34 integration + 195 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)