### PR TITLE
Simplify Cari Kart form: KKTC default, hide e-posta, single address box, Durum on edit only (#521)

### DIFF
--- a/src/IAMS.Application/Features/Customers/Commands/CreateCustomer/CreateCustomerCommandHandler.cs
+++ b/src/IAMS.Application/Features/Customers/Commands/CreateCustomer/CreateCustomerCommandHandler.cs
@@ -54,12 +54,21 @@ namespace IAMS.Application.Features.Customers.Commands.CreateCustomer
                     }
                 }
 
-                // Check if customer with email already exists for this tenant
-                var existingCustomerByEmail = await _unitOfWork.Customers.GetByEmailAsync(request.CustomerDto.Email);
-                if (existingCustomerByEmail != null)
+                // E-posta is hidden in the UI; generate a unique placeholder when blank
+                // (same scheme as the policy-import paths — Email has a unique index).
+                if (string.IsNullOrWhiteSpace(request.CustomerDto.Email))
                 {
-                    _logger.LogWarning("Customer creation failed: Email already exists");
-                    return Result<CustomerDto>.ValidationFailure("Bu e-posta adresi ile kayıtlı bir müşteri zaten mevcut", new List<string>());
+                    request.CustomerDto.Email = $"noemail_{Guid.NewGuid():N}@temp.com";
+                }
+                else
+                {
+                    // Check if customer with email already exists for this tenant
+                    var existingCustomerByEmail = await _unitOfWork.Customers.GetByEmailAsync(request.CustomerDto.Email);
+                    if (existingCustomerByEmail != null)
+                    {
+                        _logger.LogWarning("Customer creation failed: Email already exists");
+                        return Result<CustomerDto>.ValidationFailure("Bu e-posta adresi ile kayıtlı bir müşteri zaten mevcut", new List<string>());
+                    }
                 }
 
                 // Check if customer with phone number already exists for this tenant

--- a/src/IAMS.Web/Components/Pages/Customers/CustomerDetails.razor
+++ b/src/IAMS.Web/Components/Pages/Customers/CustomerDetails.razor
@@ -166,14 +166,6 @@ else
                                 </MudCardHeader>
                                 <MudCardContent>
                                     <MudStack Spacing="3">
-                                        @if (!string.IsNullOrEmpty(customer.Email))
-                                        {
-                                            <MudStack Row Justify="Justify.SpaceBetween">
-                                                <MudText Typo="Typo.body2" Color="Color.Secondary">E-posta:</MudText>
-                                                <MudLink Href="@($"mailto:{customer.Email}")">@customer.Email</MudLink>
-                                            </MudStack>
-                                        }
-                                        
                                         @if (!string.IsNullOrEmpty(customer.MobilePhoneNumber))
                                         {
                                             <MudStack Row Justify="Justify.SpaceBetween">
@@ -207,7 +199,7 @@ else
                                     <MudStack Spacing="2">
                                         @if (!string.IsNullOrEmpty(customer.Address1))
                                         {
-                                            <MudText Typo="Typo.body2" Color="Color.Secondary">Adres 1:</MudText>
+                                            <MudText Typo="Typo.body2" Color="Color.Secondary">Adres:</MudText>
                                             <MudText Typo="Typo.body1">@customer.Address1</MudText>
                                         }
                                         

--- a/src/IAMS.Web/Components/Pages/Customers/CustomerForm.razor
+++ b/src/IAMS.Web/Components/Pages/Customers/CustomerForm.razor
@@ -69,18 +69,21 @@
                                         </MudSelect>
                                     </MudItem>
                                 }
-                                <MudItem xs="12" md="4">
-                                    <MudSelect @bind-Value="model.Status"
-                                             Label="Durum *"
-                                             Variant="Variant.Outlined"
-                                             Required="true"
-                                             T="CustomerStatus">
-                                        <MudSelectItem T="CustomerStatus" Value="@CustomerStatus.Active">Aktif</MudSelectItem>
-                                        <MudSelectItem T="CustomerStatus" Value="@CustomerStatus.Inactive">Pasif</MudSelectItem>
-                                        <MudSelectItem T="CustomerStatus" Value="@CustomerStatus.Prospect">Aday Müşteri</MudSelectItem>
-                                        <MudSelectItem T="CustomerStatus" Value="@CustomerStatus.Former">Eski Müşteri</MudSelectItem>
-                                    </MudSelect>
-                                </MudItem>
+                                @if (IsEdit)
+                                {
+                                    <MudItem xs="12" md="4">
+                                        <MudSelect @bind-Value="model.Status"
+                                                 Label="Durum *"
+                                                 Variant="Variant.Outlined"
+                                                 Required="true"
+                                                 T="CustomerStatus">
+                                            <MudSelectItem T="CustomerStatus" Value="@CustomerStatus.Active">Aktif</MudSelectItem>
+                                            <MudSelectItem T="CustomerStatus" Value="@CustomerStatus.Inactive">Pasif</MudSelectItem>
+                                            <MudSelectItem T="CustomerStatus" Value="@CustomerStatus.Prospect">Aday Müşteri</MudSelectItem>
+                                            <MudSelectItem T="CustomerStatus" Value="@CustomerStatus.Former">Eski Müşteri</MudSelectItem>
+                                        </MudSelect>
+                                    </MudItem>
+                                }
                             </MudGrid>
                         </MudCardContent>
                     </MudCard>
@@ -131,18 +134,6 @@
                                                      For="@(() => model.DateOfBirth)" />
                                     </MudItem>
                                 }
-                                <MudItem xs="12" md="6">
-                                    <MudSelect @bind-Value="model.NationalityCountryId"
-                                             Label="Uyruk"
-                                             Variant="Variant.Outlined"
-                                             T="int?"
-                                             Clearable="true">
-                                        @foreach (var country in countries)
-                                        {
-                                            <MudSelectItem T="int?" Value="@((int?)country.Id)">@country.NameTr (@country.Code)</MudSelectItem>
-                                        }
-                                    </MudSelect>
-                                </MudItem>
                             </MudGrid>
                         </MudCardContent>
                     </MudCard>
@@ -183,6 +174,18 @@
                                                 Required="true"
                                                 For="@(() => model.IdentificationNumber)" />
                                 </MudItem>
+                                <MudItem xs="12" md="6">
+                                    <MudSelect @bind-Value="model.NationalityCountryId"
+                                             Label="Uyruk"
+                                             Variant="Variant.Outlined"
+                                             T="int?"
+                                             Clearable="true">
+                                        @foreach (var country in countries)
+                                        {
+                                            <MudSelectItem T="int?" Value="@((int?)country.Id)">@country.NameTr (@country.Code)</MudSelectItem>
+                                        }
+                                    </MudSelect>
+                                </MudItem>
                             </MudGrid>
                         </MudCardContent>
                     </MudCard>
@@ -198,14 +201,6 @@
                         </MudCardHeader>
                         <MudCardContent>
                             <MudGrid>
-                                <MudItem xs="12" md="6">
-                                    <MudTextField @bind-Value="model.Email"
-                                                Label="E-posta *"
-                                                Variant="Variant.Outlined"
-                                                InputType="InputType.Email"
-                                                Required="true"
-                                                For="@(() => model.Email)" />
-                                </MudItem>
                                 <MudItem xs="12" md="6">
                                     <MudTextField @bind-Value="model.HomePhone"
                                                 Label="Ev Telefonu"
@@ -245,76 +240,11 @@
                             </CardHeaderContent>
                         </MudCardHeader>
                         <MudCardContent>
-                            <MudGrid>
-                                <MudItem xs="12" md="6">
-                                    <MudTextField @bind-Value="model.Address1"
-                                                Label="Adres 1"
-                                                Variant="Variant.Outlined"
-                                                Lines="2"
-                                                For="@(() => model.Address1)" />
-                                </MudItem>
-                                <MudItem xs="12" md="6">
-                                    <MudTextField @bind-Value="model.Address2"
-                                                Label="Adres 2"
-                                                Variant="Variant.Outlined"
-                                                Lines="2"
-                                                For="@(() => model.Address2)" />
-                                </MudItem>
-                                <MudItem xs="12" md="6">
-                                    <MudSelect 
-                                             Label="Şehir"
-                                             Variant="Variant.Outlined"
-                                             T="int?"
-                                             Clearable="true"
-                                               ValueChanged="@((int? value) => OnCityChanged(value))">
-                                        @foreach (var city in cities)
-                                        {
-                                            <MudSelectItem T="int?" Value="@((int?)city.Id)">@city.NameTr</MudSelectItem>
-                                        }
-                                    </MudSelect>
-                                </MudItem>
-                                <MudItem xs="12" md="6">
-                                    <MudSelect 
-                                             Label="Mahalle"
-                                             Variant="Variant.Outlined"
-                                             T="int?"
-                                             Clearable="true"
-                                             Disabled="@(!model.CityId.HasValue)"
-                                               ValueChanged="@((int? value) => OnDistrictChanged(value))">
-                                        @foreach (var district in filteredDistricts)
-                                        {
-                                            <MudSelectItem T="int?" Value="@((int?)district.Id)">@district.NameTr</MudSelectItem>
-                                        }
-                                    </MudSelect>
-                                </MudItem>
-                                <MudItem xs="12" md="6">
-                                    <MudSelect 
-                                             Label="Bucak"
-                                             Variant="Variant.Outlined"
-                                             T="int?"
-                                             Clearable="true"
-                                             Disabled="@(!model.DistrictId.HasValue)"
-                                               ValueChanged="@((int? value) => OnSubdistrictChanged(value))">
-                                        @foreach (var subdistrict in filteredSubdistricts)
-                                        {
-                                            <MudSelectItem T="int?" Value="@((int?)subdistrict.Id)">@subdistrict.NameTr</MudSelectItem>
-                                        }
-                                    </MudSelect>
-                                </MudItem>
-                                <MudItem xs="12" md="6">
-                                    <MudSelect @bind-Value="model.VillageId"
-                                             Label="Köy"
-                                             Variant="Variant.Outlined"
-                                             T="int?"
-                                             Clearable="true"
-                                             Disabled="@(!model.SubdistrictId.HasValue)">
-                                        @foreach (var village in filteredVillages)
-                                        {
-                                            <MudSelectItem T="int?" Value="@((int?)village.Id)">@village.NameTr</MudSelectItem>
-                                        }
-                                    </MudSelect>
-                                </MudItem>
-                            </MudGrid>
+                            <MudTextField @bind-Value="model.Address1"
+                                        Label="Adres"
+                                        Variant="Variant.Outlined"
+                                        Lines="3"
+                                        For="@(() => model.Address1)" />
                         </MudCardContent>
                     </MudCard>
                 </MudItem>
@@ -406,26 +336,6 @@
     // Parametric data
     private List<CountryDto> countries = new();
     private List<OccupationDto> occupations = new();
-    private List<CityDto> cities = new();
-    private List<DistrictDto> districts = new();
-    private List<SubdistrictDto> subdistricts = new();
-    private List<VillageDto> villages = new();
-
-    // Filtered hierarchical data
-    private List<DistrictDto> filteredDistricts => 
-        model.CityId.HasValue 
-            ? districts.Where(d => d.CityId == model.CityId.Value).ToList() 
-            : new List<DistrictDto>();
-
-    private List<SubdistrictDto> filteredSubdistricts => 
-        model.DistrictId.HasValue 
-            ? subdistricts.Where(s => s.DistrictId == model.DistrictId.Value).ToList() 
-            : new List<SubdistrictDto>();
-
-    private List<VillageDto> filteredVillages => 
-        model.SubdistrictId.HasValue 
-            ? villages.Where(v => v.SubdistrictId == model.SubdistrictId.Value).ToList() 
-            : new List<VillageDto>();
 
     private bool IsEdit => CustomerId.HasValue;
 
@@ -444,6 +354,10 @@
             model.Gender = Gender.Male;
             model.Status = CustomerStatus.Active;
             model.IdentificationType = IdentificationType.IdCard;
+            // Uyruk defaults to KKTC (nüfus country code 601)
+            model.NationalityCountryId = countries.FirstOrDefault(c =>
+                c.Code == "601" ||
+                (c.NameTr?.Contains("Kıbrıs", StringComparison.OrdinalIgnoreCase) ?? false))?.Id;
         }
     }
 
@@ -478,18 +392,6 @@
 
             var occupationsResult = await ParametricApi.GetOccupationsAsync();
             occupations = occupationsResult.IsSuccess ? occupationsResult.Data ?? new List<OccupationDto>() : new List<OccupationDto>();
-
-            var citiesResult = await ParametricApi.GetCitiesAsync();
-            cities = citiesResult.IsSuccess ? citiesResult.Data ?? new List<CityDto>() : new List<CityDto>();
-
-            var districtsResult = await ParametricApi.GetDistrictsAsync();
-            districts = districtsResult.IsSuccess ? districtsResult.Data ?? new List<DistrictDto>() : new List<DistrictDto>();
-
-            var subdistrictsResult = await ParametricApi.GetSubdistrictsAsync();
-            subdistricts = subdistrictsResult.IsSuccess ? subdistrictsResult.Data ?? new List<SubdistrictDto>() : new List<SubdistrictDto>();
-
-            var villagesResult = await ParametricApi.GetVillagesAsync();
-            villages = villagesResult.IsSuccess ? villagesResult.Data ?? new List<VillageDto>() : new List<VillageDto>();
         }
         catch (Exception ex)
         {
@@ -536,30 +438,6 @@
             Snackbar.Add($"Müşteri bilgileri yüklenirken hata oluştu: {ex.Message}", MudBlazor.Severity.Error);
             GoBack();
         }
-    }
-
-    private void OnCityChanged(int? cityId)
-    {
-        model.CityId = cityId;
-        // Clear dependent fields when city changes
-        model.DistrictId = null;
-        model.SubdistrictId = null;
-        model.VillageId = null;
-    }
-
-    private void OnDistrictChanged(int? districtId)
-    {
-        model.DistrictId = districtId;
-        // Clear dependent fields when district changes
-        model.SubdistrictId = null;
-        model.VillageId = null;
-    }
-
-    private void OnSubdistrictChanged(int? subdistrictId)
-    {
-        model.SubdistrictId = subdistrictId;
-        // Clear dependent field when subdistrict changes
-        model.VillageId = null;
     }
 
     private async Task OnValidSubmit()

--- a/src/IAMS.Web/Components/Pages/Home.razor
+++ b/src/IAMS.Web/Components/Pages/Home.razor
@@ -149,7 +149,7 @@
                                         <div class="flex-grow-1">
                                             <MudText Typo="Typo.body2">@customer.FullName</MudText>
                                             <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                                @customer.Email
+                                                @customer.CustomerCode
                                             </MudText>
                                         </div>
                                         <MudText Typo="Typo.caption" Color="Color.Secondary">

--- a/src/IAMS.Web/Components/Pages/Policies/PolicyForm.razor
+++ b/src/IAMS.Web/Components/Pages/Policies/PolicyForm.razor
@@ -134,7 +134,7 @@
                                                        MaxItems="50"
                                                        DebounceInterval="150"
                                                        AdornmentIcon="@Icons.Material.Filled.Search"
-                                                       HelperText="Müşteri adı veya e-posta ile arayın">
+                                                       HelperText="Müşteri adı ile arayın">
                                             <ItemTemplate Context="customerItem">
                                                 <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
                                                     <MudAvatar Color="Color.Primary" Size="Size.Small">
@@ -142,7 +142,7 @@
                                                     </MudAvatar>
                                                     <MudStack Spacing="0">
                                                         <MudText Typo="Typo.body2">@customerItem.FirstName @customerItem.LastName</MudText>
-                                                        <MudText Typo="Typo.caption" Color="Color.Secondary">@customerItem.Email</MudText>
+                                                        <MudText Typo="Typo.caption" Color="Color.Secondary">@customerItem.CustomerCode</MudText>
                                                     </MudStack>
                                                 </MudStack>
                                             </ItemTemplate>

--- a/src/IAMS.Web/Components/Pages/Reports/CustomerReport.razor
+++ b/src/IAMS.Web/Components/Pages/Reports/CustomerReport.razor
@@ -84,7 +84,7 @@
                                     <MudStack Spacing="0">
                                         <MudText Typo="Typo.body2">@customerItem.FirstName @customerItem.LastName</MudText>
                                         <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                            @customerItem.Email - @customerItem.CustomerCode
+                                            @customerItem.CustomerCode
                                         </MudText>
                                     </MudStack>
                                 </MudStack>
@@ -147,8 +147,8 @@
                         </MudItem>
                         <MudItem xs="12" sm="6" md="3">
                             <MudStack Spacing="1">
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">E-posta</MudText>
-                                <MudText Typo="Typo.body1">@selectedCustomer.Email</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">Müşteri Kodu</MudText>
+                                <MudText Typo="Typo.body1">@selectedCustomer.CustomerCode</MudText>
                             </MudStack>
                         </MudItem>
                         <MudItem xs="12" sm="6" md="3">

--- a/src/IAMS.Web/Components/Shared/CustomerSearch.razor
+++ b/src/IAMS.Web/Components/Shared/CustomerSearch.razor
@@ -29,7 +29,7 @@
                     <strong>@customer.FirstName @customer.LastName</strong>
                 </MudText>
                 <MudText Typo="Typo.caption" Color="Color.Secondary">
-                    @customer.CustomerCode - @customer.Email
+                    @customer.CustomerCode
                 </MudText>
             </MudStack>
         </MudStack>

--- a/tests/IAMS.IntegrationTests/Controllers/CustomersControllerTests.cs
+++ b/tests/IAMS.IntegrationTests/Controllers/CustomersControllerTests.cs
@@ -87,6 +87,25 @@ public class CustomersControllerTests : IClassFixture<TestWebApplicationFactory<
         customer.Email.Should().Be("mehmet.yilmaz@example.com");
     }
 
+    [Fact]
+    public async Task CreateCustomer_WithoutEmail_AutoGeneratesPlaceholder()
+    {
+        // E-posta is hidden in the UI (#521); a unique placeholder must be generated
+        // server-side so the unique index on Email is never violated.
+        var createDto = new CreateOrUpdateCustomerDto
+        {
+            FirstName = "Ayşe",
+            LastName = "Kaya",
+            MobilePhoneNumber = "+90 533 444 5566"
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/customers", createDto);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var result = await response.Content.ReadFromJsonAsync<IAMS.Shared.Models.Result<CustomerDto>>();
+        result!.Data!.Email.Should().StartWith("noemail_").And.EndWith("@temp.com");
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData("   ")]


### PR DESCRIPTION
Closes #521. User-requested Cari Kart form fixes.

- **Uyruk** defaults to **KKTC** on create — resolved from the loaded country list by nüfus code `601` (name fallback), not a hardcoded id — and now lives in the **Kimlik Bilgileri** card.
- **E-posta** is gone from the form and every display (customer details, customer search dropdown, policy form autocomplete, home recent-customers, customer report — captions show the customer code instead). DB untouched; when blank, `CreateCustomer` generates the same `noemail_<guid>@temp.com` placeholder the import paths already use, so the unique index on Email is never violated. Edit keeps the stored value invisible in the model, so updates pass validation unchanged.
- **Adres Bilgileri** is now a single free-text **Adres** box. The Şehir/Mahalle/Bucak/Köy cascade and Adres 2 are removed from the form and their four parametric lookups are no longer fetched on page load. Existing stored values are preserved on edit and still display on the details page when present.
- **Durum** dropdown is hidden on create (defaults **Aktif**) and shown on edit, as requested.

Tests: new integration test asserting blank-email create succeeds with an auto-generated placeholder. 35 integration + 195 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)