### PR TITLE
Remove customer e-mails from outstanding-balance lists (dashboard + financial report)

### DIFF
--- a/src/IAMS.Web/Components/Pages/Dashboard.razor
+++ b/src/IAMS.Web/Components/Pages/Dashboard.razor
@@ -59,10 +59,7 @@
                                 </HeaderContent>
                                 <RowTemplate>
                                     <MudTd DataLabel="Müşteri">
-                                        <div>
-                                            <MudText Typo="Typo.body2" Color="Color.Primary"><b>@context.CustomerName</b></MudText>
-                                            <MudText Typo="Typo.caption" Color="Color.Secondary">@context.CustomerEmail</MudText>
-                                        </div>
+                                        <MudText Typo="Typo.body2" Color="Color.Primary"><b>@context.CustomerName</b></MudText>
                                     </MudTd>
                                     <MudTd DataLabel="Poliçe Sayısı">@context.ActivePoliciesCount</MudTd>
                                     <MudTd DataLabel="Bekleyen Ödeme">@context.PendingPaymentsCount</MudTd>

--- a/src/IAMS.Web/Components/Pages/Reports/FinancialReports.razor
+++ b/src/IAMS.Web/Components/Pages/Reports/FinancialReports.razor
@@ -533,14 +533,12 @@
                                             <MudTable Items="customersWithOutstanding.Take(10)" Dense="true" Hover="true">
                                                 <HeaderContent>
                                                     <MudTh>Müşteri</MudTh>
-                                                    <MudTh>E-posta</MudTh>
                                                     <MudTh Style="text-align:right">Aktif Poliçe</MudTh>
                                                     <MudTh Style="text-align:right">Bekleyen Ödeme</MudTh>
                                                     <MudTh Style="text-align:right">Kalan Bakiye</MudTh>
                                                 </HeaderContent>
                                                 <RowTemplate>
                                                     <MudTd DataLabel="Müşteri">@context.CustomerName</MudTd>
-                                                    <MudTd DataLabel="E-posta">@context.CustomerEmail</MudTd>
                                                     <MudTd DataLabel="Aktif Poliçe" Style="text-align:right">@context.ActivePoliciesCount</MudTd>
                                                     <MudTd DataLabel="Bekleyen Ödeme" Style="text-align:right">@context.PendingPaymentsCount</MudTd>
                                                     <MudTd DataLabel="Kalan Bakiye" Style="text-align:right">


### PR DESCRIPTION
Follow-up to #521 (e-posta hidden from customer screens): the dashboard's **"Müşteri Bazlı Kalan Bakiye"** card still showed each customer's e-mail under the name, and the financial report's Top-10 version of the same table had a whole **E-posta** column — now mostly displaying `noemail_…@temp.com` placeholders. Both removed; dashboard rows still navigate to the customer on click.

Web-only, display-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)