### PR TITLE
Cari Kart: free-form kimlik, Cep 1/2 phones, remove meslek, plaka column (#527)

### DIFF
--- a/src/IAMS.Application/Validators/Customer/CreateCustomerValidator.cs
+++ b/src/IAMS.Application/Validators/Customer/CreateCustomerValidator.cs
@@ -22,9 +22,10 @@ namespace IAMS.Application.Validators.Customer
                 .MaximumLength(100).WithMessage("Last name must not exceed 100 characters")
                 .When(x => x.Type == CustomerType.Individual);
 
+            // No format/length rule for the identification number: old KKTC kimlik numbers
+            // were 6 digits (later extended), passports vary — only the column size applies.
             RuleFor(x => x.IdentificationNumber)
-                .Length(11).WithMessage("Identification number must be exactly 11 digits")
-                .Matches(@"^\d{11}$").WithMessage("Identification number must contain only digits")
+                .MaximumLength(50).WithMessage("Identification number must not exceed 50 characters")
                 .When(x => !string.IsNullOrEmpty(x.IdentificationNumber));
 
             RuleFor(x => x.Email)

--- a/src/IAMS.Persistence/Repositories/PolicyRepository.cs
+++ b/src/IAMS.Persistence/Repositories/PolicyRepository.cs
@@ -72,6 +72,7 @@ namespace IAMS.Persistence.Repositories
                 .Include(p => p.InsuranceCompany)
                 .Include(p => p.PolicyType)
                 .Include(p => p.Currency)
+                .Include(p => p.Vehicle) // plate shown on the Cari Kart policy list (#527)
                 .Where(p => p.CustomerId == customerId && !p.IsDeleted)
                 .OrderByDescending(p => p.CreatedOn)
                 .ToListAsync();

--- a/src/IAMS.Web/Components/Pages/Customers/CustomerDetails.razor
+++ b/src/IAMS.Web/Components/Pages/Customers/CustomerDetails.razor
@@ -169,7 +169,7 @@ else
                                         @if (!string.IsNullOrEmpty(customer.MobilePhoneNumber))
                                         {
                                             <MudStack Row Justify="Justify.SpaceBetween">
-                                                <MudText Typo="Typo.body2" Color="Color.Secondary">Cep Telefonu:</MudText>
+                                                <MudText Typo="Typo.body2" Color="Color.Secondary">Cep Telefonu 1:</MudText>
                                                 <MudLink Href="@($"tel:{customer.MobilePhoneCountryCode}{customer.MobilePhoneNumber}")">
                                                     @customer.MobilePhoneCountryCode @customer.MobilePhoneNumber
                                                 </MudLink>
@@ -179,7 +179,7 @@ else
                                         @if (!string.IsNullOrEmpty(customer.HomePhone))
                                         {
                                             <MudStack Row Justify="Justify.SpaceBetween">
-                                                <MudText Typo="Typo.body2" Color="Color.Secondary">Ev Telefonu:</MudText>
+                                                <MudText Typo="Typo.body2" Color="Color.Secondary">Cep Telefonu 2:</MudText>
                                                 <MudLink Href="@($"tel:{customer.HomePhone}")">@customer.HomePhone</MudLink>
                                             </MudStack>
                                         }
@@ -288,6 +288,7 @@ else
                                 <MudTh>Poliçe No</MudTh>
                                 <MudTh>Z.No</MudTh>
                                 <MudTh>Poliçe Türü</MudTh>
+                                <MudTh>Plaka</MudTh>
                                 <MudTh>Sigorta Şirketi</MudTh>
                                 <MudTh>Başlangıç</MudTh>
                                 <MudTh>Bitiş</MudTh>
@@ -316,6 +317,7 @@ else
                                     </MudStack>
                                 </MudTd>
                                 <MudTd DataLabel="Poliçe Türü">@context.PolicyType.Name</MudTd>
+                                <MudTd DataLabel="Plaka">@GetPlateForPolicy(context)</MudTd>
                                 <MudTd DataLabel="Sigorta Şirketi">@context.InsuranceCompany.Name</MudTd>
                                 <MudTd DataLabel="Başlangıç">@context.StartDate.ToString("dd.MM.yyyy")</MudTd>
                                 <MudTd DataLabel="Bitiş">@context.EndDate.ToString("dd.MM.yyyy")</MudTd>
@@ -771,6 +773,22 @@ else
         PolicyStatus.Suspended => "Askıya Alınmış",
         _ => status.ToString()
     };
+
+    // Plaka is shown only for traffic-family policies (trafik/kasko variants, any
+    // spelling including the Turkish İ); the column stays empty for other types.
+    private static readonly string[] TrafficMarkers = { "TRAFIK", "TRAFFIC", "TRAFIC", "KASKO" };
+
+    private static string? GetPlateForPolicy(PolicyDto policy)
+    {
+        var typeName = policy.PolicyType?.Name;
+        if (string.IsNullOrEmpty(typeName))
+        {
+            return null;
+        }
+
+        var normalized = typeName.ToUpperInvariant().Replace('İ', 'I').Replace('ı', 'I');
+        return TrafficMarkers.Any(m => normalized.Contains(m)) ? policy.Vehicle?.PlateNumber : null;
+    }
 
     private Color GetPolicyStatusColor(PolicyStatus status) => status switch
     {

--- a/src/IAMS.Web/Components/Pages/Customers/CustomerForm.razor
+++ b/src/IAMS.Web/Components/Pages/Customers/CustomerForm.razor
@@ -199,29 +199,17 @@
                         <MudCardContent Class="pt-2">
                             <MudGrid Spacing="2">
                                 <MudItem xs="12" md="6">
-                                    <MudTextField @bind-Value="model.HomePhone"
-                                                Label="Ev Telefonu"
-                                                Variant="Variant.Outlined" Margin="Margin.Dense"
-                                                Mask="@(new PatternMask("(000) 000-0000"))"
-                                                For="@(() => model.HomePhone)" />
-                                </MudItem>
-                                <MudItem xs="12" md="6">
-                                    <MudSelect @bind-Value="model.MobilePhoneCountryCode"
-                                             Label="Cep Tel. Ülke Kodu"
-                                             Variant="Variant.Outlined" Margin="Margin.Dense"
-                                             T="string"
-                                             Clearable="true">
-                                        @foreach (var country in countries.Where(c => !string.IsNullOrEmpty(c.PhoneCode)))
-                                        {
-                                            <MudSelectItem T="string" Value="@country.PhoneCode">@country.PhoneCode - @country.NameTr</MudSelectItem>
-                                        }
-                                    </MudSelect>
-                                </MudItem>
-                                <MudItem xs="12" md="6">
                                     <MudTextField @bind-Value="model.MobilePhoneNumber"
-                                                Label="Cep Telefonu No"
+                                                Label="Cep Telefonu 1"
                                                 Variant="Variant.Outlined" Margin="Margin.Dense"
                                                 For="@(() => model.MobilePhoneNumber)" />
+                                </MudItem>
+                                <MudItem xs="12" md="6">
+                                    @* Stored in the HomePhone column — label only, no DB change *@
+                                    <MudTextField @bind-Value="model.HomePhone"
+                                                Label="Cep Telefonu 2"
+                                                Variant="Variant.Outlined" Margin="Margin.Dense"
+                                                For="@(() => model.HomePhone)" />
                                 </MudItem>
                             </MudGrid>
                         </MudCardContent>
@@ -246,37 +234,6 @@
                     </MudCard>
                 </MudItem>
 
-                <!-- Professional Information -->
-                @if (model.Type == CustomerType.Individual)
-                {
-                    <MudItem xs="12">
-                        <MudCard>
-                            <MudCardHeader Class="pb-0">
-                                <CardHeaderContent>
-                                    <MudText Typo="Typo.subtitle1" Style="font-weight:600">Mesleki Bilgiler</MudText>
-                                </CardHeaderContent>
-                            </MudCardHeader>
-                            <MudCardContent Class="pt-2">
-                                <MudGrid Spacing="2">
-                                    <MudItem xs="12" md="6">
-                                        <MudSelect @key="@occupations.Count"
-                                                 @bind-Value="model.OccupationId"
-                                                 Label="Meslek"
-                                                 Variant="Variant.Outlined" Margin="Margin.Dense"
-                                                 T="int?"
-                                                 Clearable="true"
-                                                 ToStringFunc="@OccupationDisplayName">
-                                            @foreach (var occupation in occupations)
-                                            {
-                                                <MudSelectItem T="int?" Value="@((int?)occupation.Id)">@occupation.NameTr</MudSelectItem>
-                                            }
-                                        </MudSelect>
-                                    </MudItem>
-                                </MudGrid>
-                            </MudCardContent>
-                        </MudCard>
-                    </MudItem>
-                }
 
                 <!-- Notes -->
                 <MudItem xs="12">
@@ -334,7 +291,6 @@
 
     // Parametric data
     private List<CountryDto> countries = new();
-    private List<OccupationDto> occupations = new();
 
     private bool IsEdit => CustomerId.HasValue;
 
@@ -381,11 +337,6 @@
         id == null
             ? string.Empty
             : countries.FirstOrDefault(c => c.Id == id) is { } c ? $"{c.NameTr} ({c.Code})" : string.Empty;
-
-    private string OccupationDisplayName(int? id) =>
-        id == null
-            ? string.Empty
-            : occupations.FirstOrDefault(o => o.Id == id)?.NameTr ?? string.Empty;
 
     protected override async Task OnInitializedAsync()
     {
@@ -435,9 +386,6 @@
             // Load all parametric data in parallel
             var countriesResult = await ParametricApi.GetCountriesAsync();
             countries = countriesResult.IsSuccess ? countriesResult.Data ?? new List<CountryDto>() : new List<CountryDto>();
-
-            var occupationsResult = await ParametricApi.GetOccupationsAsync();
-            occupations = occupationsResult.IsSuccess ? occupationsResult.Data ?? new List<OccupationDto>() : new List<OccupationDto>();
 
             // KKTC (nüfus country code 601) drives the uyruk default and the kimlik türü rule
             kktcCountryId = countries.FirstOrDefault(c =>


### PR DESCRIPTION
Closes #527.

1. **Kimlik validation removed** — the 11-digit rule rejected legitimate old 6-digit KKTC kimlik numbers. Now only the DB column limit (50) applies.
2. **İletişim = Cep Telefonu 1 + Cep Telefonu 2** — Ev Telefonu and the Ülke Kodu select are gone from the form. Cep 2 is stored in the existing `HomePhone` column (label change only, zero DB work, old data intact); details page relabelled to match. Stored country codes survive edits invisibly.
3. **Meslek removed from the form** (card + occupations lookup no longer fetched). Details page still shows a stored meslek; edit round-trips the value.
4. **Plaka column** on Cari Kart > Poliçeler — always present; filled with the vehicle plate for traffic-family policies (trafik/traffic/trafic/kasko, Turkish İ handled), empty otherwise. `GetPoliciesByCustomerIdAsync` now includes the Vehicle navigation.

**Browser-verified in the local podman environment**: form shows exactly the new layout (screenshot-checked), and a customer with kimlik `123456` saves successfully. 195 unit + 35 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)