### PR TITLE
Zeyil imports: accept orphans with warnings, visible + self-linking, signed auto-pay (#528)

### DIFF
--- a/src/IAMS.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/src/IAMS.Application/Extensions/ServiceCollectionExtensions.cs
@@ -78,6 +78,7 @@ namespace IAMS.Application.Extensions
             services.AddScoped<IExcelFileValidator, ExcelFileValidator>();
             services.AddScoped<IExcelPolicyParser, ExcelPolicyParser>();
             services.AddScoped<IImportAutoPaymentService, ImportAutoPaymentService>();
+            services.AddScoped<IEndorsementLinkService, EndorsementLinkService>();
 
             // Register Focused Policy Services (replaces bloated repository interface)
             services.AddScoped<IPolicyQueryService, PolicyQueryService>();

--- a/src/IAMS.Application/Features/Policies/Commands/ImportPolicies/ImportPoliciesCommandHandler.cs
+++ b/src/IAMS.Application/Features/Policies/Commands/ImportPolicies/ImportPoliciesCommandHandler.cs
@@ -22,6 +22,7 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
         private readonly IPolicyQueryService _policyQueryService;
         private readonly ICustomerCodeGenerator _customerCodeGenerator;
         private readonly IImportAutoPaymentService _autoPaymentService;
+        private readonly IEndorsementLinkService _endorsementLinkService;
         private readonly ILogger<ImportPoliciesCommandHandler> _logger;
 
         public ImportPoliciesCommandHandler(
@@ -31,6 +32,7 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
             IPolicyQueryService policyQueryService,
             ICustomerCodeGenerator customerCodeGenerator,
             IImportAutoPaymentService autoPaymentService,
+            IEndorsementLinkService endorsementLinkService,
             ILogger<ImportPoliciesCommandHandler> logger)
         {
             _unitOfWork = unitOfWork;
@@ -39,6 +41,7 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
             _policyQueryService = policyQueryService;
             _customerCodeGenerator = customerCodeGenerator;
             _autoPaymentService = autoPaymentService;
+            _endorsementLinkService = endorsementLinkService;
             _logger = logger;
         }
 
@@ -96,7 +99,7 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
                 {
                     try
                     {
-                        var policy = await ImportSinglePolicyAsync(policyDto, userId, insuranceCompanyId, cancellationToken);
+                        var policy = await ImportSinglePolicyAsync(policyDto, userId, insuranceCompanyId, result, cancellationToken);
                         result.SuccessCount++;
                         result.ImportedPolicyIds.Add(policy.Id);
                     }
@@ -126,7 +129,7 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
 
         // The remaining import logic stays in the handler for now
 
-        private async Task<Policy> ImportSinglePolicyAsync(ImportPolicyDto dto, string userId, int insuranceCompanyId, CancellationToken cancellationToken)
+        private async Task<Policy> ImportSinglePolicyAsync(ImportPolicyDto dto, string userId, int insuranceCompanyId, PolicyImportResultDto result, CancellationToken cancellationToken)
         {
             // Lookup or create related entities
             var customer = await GetOrCreateCustomerAsync(dto);
@@ -141,13 +144,15 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
 
             if (dto.InnerCode != "000" && !string.IsNullOrEmpty(dto.PolicyNumber))
             {
-                // Find the original policy (the one with InnerCode = "000")
+                // Find the original policy (the one with InnerCode = "000"). A zeyil without
+                // its original is imported anyway with a warning — it shows as its own row
+                // until the original arrives, when IEndorsementLinkService attaches it (#528).
                 originalPolicy = await _unitOfWork.Policies.GetByPolicyNumberAsync(dto.PolicyNumber);
                 if (originalPolicy == null)
                 {
-                    throw new InvalidOperationException(
-                        $"Original policy not found for endorsement: {dto.PolicyNumber}. " +
-                        $"InnerCode: {dto.InnerCode}");
+                    result.Warnings.Add(
+                        $"Zeyil ana poliçesi olmadan içe aktarıldı: Poliçe No={dto.PolicyNumber}, Zeyil No={dto.InnerCode}. " +
+                        "Ana poliçe içe aktarıldığında otomatik olarak bağlanacaktır.");
                 }
             }
 
@@ -191,6 +196,13 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
             await _unitOfWork.Policies.AddAsync(policy);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
+            // If this row is an original, attach any zeyils that were imported before it
+            if (policy.InnerCode == "000" &&
+                await _endorsementLinkService.LinkOrphanEndorsementsAsync(policy, cancellationToken) > 0)
+            {
+                await _unitOfWork.SaveChangesAsync(cancellationToken);
+            }
+
             // Traffic-family policies (Trafik/Kasko variants) are auto-marked fully paid,
             // unless the agency turned the AutoPayMandatoryPolicies setting off (see #515).
             bool autoPay = await _autoPaymentService.ShouldAutoPayAsync(policyType, cancellationToken);
@@ -206,8 +218,10 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
                 paymentAmount = dto.PaidAmount.Value;
             }
 
-            // Create payment if there's an amount to record
-            if (paymentAmount > 0)
+            // Create payment if there's an amount to record. Signed under the auto-pay rule:
+            // a negative-premium zeyil (iade) gets a matching negative payment so the
+            // traffic chain stays at zero balance (#528).
+            if (paymentAmount != 0)
             {
                 var payment = new PolicyPayment
                 {
@@ -217,7 +231,9 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPolicies
                     PaymentMethod = ParsePaymentMethod(dto.PaymentMethod),
                     Status = PaymentStatus.Completed,
                     CurrencyId = currency.Id,
-                    Notes = autoPay ? _autoPaymentService.AutoPaymentNote : "Initial payment from import",
+                    Notes = autoPay
+                        ? (paymentAmount < 0 ? _autoPaymentService.AutoRefundNote : _autoPaymentService.AutoPaymentNote)
+                        : "Initial payment from import",
                     CreatedBy = userId,
                     CreatedOn = DateTime.UtcNow,
                     ModifiedBy = userId,

--- a/src/IAMS.Application/Features/Policies/Commands/ImportPoliciesWithMapping/ImportPoliciesWithMappingCommandHandler.cs
+++ b/src/IAMS.Application/Features/Policies/Commands/ImportPoliciesWithMapping/ImportPoliciesWithMappingCommandHandler.cs
@@ -24,17 +24,20 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPoliciesWithMapping
         private readonly IUnitOfWork _unitOfWork;
         private readonly ICustomerCodeGenerator _customerCodeGenerator;
         private readonly IImportAutoPaymentService _autoPaymentService;
+        private readonly IEndorsementLinkService _endorsementLinkService;
         private readonly ILogger<ImportPoliciesWithMappingCommandHandler> _logger;
 
         public ImportPoliciesWithMappingCommandHandler(
             IUnitOfWork unitOfWork,
             ICustomerCodeGenerator customerCodeGenerator,
             IImportAutoPaymentService autoPaymentService,
+            IEndorsementLinkService endorsementLinkService,
             ILogger<ImportPoliciesWithMappingCommandHandler> logger)
         {
             _unitOfWork = unitOfWork;
             _customerCodeGenerator = customerCodeGenerator;
             _autoPaymentService = autoPaymentService;
+            _endorsementLinkService = endorsementLinkService;
             _logger = logger;
         }
 
@@ -117,6 +120,7 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPoliciesWithMapping
                             vehicleCache,
                             policyCache,
                             codeState,
+                            result,
                             cancellationToken);
 
                         result.SuccessCount++;
@@ -182,6 +186,7 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPoliciesWithMapping
             Dictionary<string, Vehicle> vehicleCache,
             Dictionary<string, Policy> policyCache,
             CustomerCodeState codeState,
+            PolicyImportResultDto result,
             CancellationToken cancellationToken)
         {
             var dto = mappedPolicy.OriginalImportData;
@@ -307,13 +312,15 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPoliciesWithMapping
                 }
                 else
                 {
-                    // Not in batch, check database
+                    // Not in batch, check database. A zeyil without its original is imported
+                    // anyway with a warning — it shows as its own row in the UI until the
+                    // original arrives, when IEndorsementLinkService attaches it (#528).
                     originalPolicy = await _unitOfWork.Policies.GetByPolicyNumberAsync(policyNumber);
                     if (originalPolicy == null)
                     {
-                        throw new InvalidOperationException(
-                            $"Original policy not found for endorsement: PolicyNumber={policyNumber}, InnerCode={innerCode}. " +
-                            $"The original policy (InnerCode=000) must be in the import file or database.");
+                        result.Warnings.Add(
+                            $"Zeyil ana poliçesi olmadan içe aktarıldı: Poliçe No={policyNumber}, Zeyil No={innerCode}. " +
+                            "Ana poliçe içe aktarıldığında otomatik olarak bağlanacaktır.");
                     }
                 }
             }
@@ -356,6 +363,13 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPoliciesWithMapping
             policyCache[policyKey] = policy;
             _logger.LogDebug("Added policy to cache: Company={CompanyId}, Type={TypeId}, Policy={PolicyNumber}, InnerCode={InnerCode}",
                 insuranceCompanyId, policyType.Id, policyNumber, innerCode);
+
+            // If this row is an original, attach any orphan zeyils imported in earlier runs
+            // (the batch's final SaveChanges persists the links)
+            if (innerCode == "000")
+            {
+                await _endorsementLinkService.LinkOrphanEndorsementsAsync(policy, cancellationToken);
+            }
 
             // Create initial payment if applicable
             await CreateInitialPaymentIfNeeded(policy, policyType, dto, currency.Id, userId, cancellationToken);
@@ -634,10 +648,11 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPoliciesWithMapping
             // shared rule also honors the agency's AutoPayMandatoryPolicies setting (#515).
             bool requiresFullPayment = await _autoPaymentService.ShouldAutoPayAsync(policyType, cancellationToken);
 
+            // Signed amount for the auto-pay rule: a negative-premium zeyil (iade) gets a
+            // matching negative payment so the traffic chain stays at zero balance (#528).
             decimal paymentAmount = 0;
             if (requiresFullPayment)
             {
-                // Create full payment for the premium amount → zero outstanding balance
                 paymentAmount = policy.PremiumAmount; // Use actual policy premium, not DTO
 
                 _logger.LogInformation(
@@ -652,7 +667,7 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPoliciesWithMapping
                 paymentAmount = dto.PaidAmount.Value;
             }
 
-            if (paymentAmount > 0)
+            if (paymentAmount != 0)
             {
                 var payment = new PolicyPayment
                 {
@@ -663,7 +678,7 @@ namespace IAMS.Application.Features.Policies.Commands.ImportPoliciesWithMapping
                     Status = PaymentStatus.Completed,
                     CurrencyId = currencyId,
                     Notes = requiresFullPayment
-                        ? _autoPaymentService.AutoPaymentNote
+                        ? (paymentAmount < 0 ? _autoPaymentService.AutoRefundNote : _autoPaymentService.AutoPaymentNote)
                         : "Initial payment from import",
                     CreatedBy = userId,
                     CreatedOn = DateTime.UtcNow,

--- a/src/IAMS.Application/Features/Policies/Commands/SyncPoliciesFromMySql/SyncPoliciesFromMySqlCommandHandler.cs
+++ b/src/IAMS.Application/Features/Policies/Commands/SyncPoliciesFromMySql/SyncPoliciesFromMySqlCommandHandler.cs
@@ -108,7 +108,14 @@ namespace IAMS.Application.Features.Policies.Commands.SyncPoliciesFromMySql
                     TotalRows = policies.Count
                 };
 
-                foreach (var policyDto in policies)
+                // Originals (InnerCode=000) first, so endorsements from the same sync find
+                // their main policy in the database (same ordering as the mapping import).
+                var sortedPolicies = policies
+                    .OrderBy(p => p.InnerCode != "000" && p.InnerCode != null ? 1 : 0)
+                    .ThenBy(p => p.PolicyNumber)
+                    .ToList();
+
+                foreach (var policyDto in sortedPolicies)
                 {
                     try
                     {
@@ -196,11 +203,20 @@ namespace IAMS.Application.Features.Policies.Commands.SyncPoliciesFromMySql
             var currency = await GetCurrencyAsync(dto.CurrencyCode ?? "TRY");
             var vehicle = await GetOrCreateVehicleAsync(dto, customer.Id, userId);
 
-            // Check if this is an endorsement
+            // Check if this is an endorsement (zeyil). An endorsement must never be imported
+            // without its original policy: an orphan (OriginalPolicyId = null) is invisible
+            // in the customer's policy list yet still counts in balances (#528). Failing the
+            // row here lands it in the sync's error list; the rest of the sync continues.
             Policy? originalPolicy = null;
             if (dto.InnerCode != "000" && !string.IsNullOrEmpty(dto.PolicyNumber))
             {
                 originalPolicy = await _unitOfWork.Policies.GetByPolicyNumberAsync(dto.PolicyNumber);
+                if (originalPolicy == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Original policy not found for endorsement: PolicyNumber={dto.PolicyNumber}, InnerCode={dto.InnerCode}. " +
+                        $"The original policy (InnerCode=000) must exist in the database or be part of this sync.");
+                }
             }
 
             // Build EnsuredEntity string (Sigortalı) - same pattern as CSV import

--- a/src/IAMS.Application/Features/Policies/Commands/SyncPoliciesFromMySql/SyncPoliciesFromMySqlCommandHandler.cs
+++ b/src/IAMS.Application/Features/Policies/Commands/SyncPoliciesFromMySql/SyncPoliciesFromMySqlCommandHandler.cs
@@ -17,6 +17,7 @@ namespace IAMS.Application.Features.Policies.Commands.SyncPoliciesFromMySql
         private readonly IMySqlPolicyImportService _mySqlImportService;
         private readonly ICustomerCodeGenerator _customerCodeGenerator;
         private readonly IImportAutoPaymentService _autoPaymentService;
+        private readonly IEndorsementLinkService _endorsementLinkService;
         private readonly ILogger<SyncPoliciesFromMySqlCommandHandler> _logger;
 
         public SyncPoliciesFromMySqlCommandHandler(
@@ -24,12 +25,14 @@ namespace IAMS.Application.Features.Policies.Commands.SyncPoliciesFromMySql
             IMySqlPolicyImportService mySqlImportService,
             ICustomerCodeGenerator customerCodeGenerator,
             IImportAutoPaymentService autoPaymentService,
+            IEndorsementLinkService endorsementLinkService,
             ILogger<SyncPoliciesFromMySqlCommandHandler> logger)
         {
             _unitOfWork = unitOfWork;
             _mySqlImportService = mySqlImportService;
             _customerCodeGenerator = customerCodeGenerator;
             _autoPaymentService = autoPaymentService;
+            _endorsementLinkService = endorsementLinkService;
             _logger = logger;
         }
 
@@ -120,7 +123,7 @@ namespace IAMS.Application.Features.Policies.Commands.SyncPoliciesFromMySql
                     try
                     {
                         var policy = await ImportSinglePolicyAsync(
-                            policyDto, request.UserId, request.InsuranceCompanyId, cancellationToken);
+                            policyDto, request.UserId, request.InsuranceCompanyId, result, cancellationToken);
 
                         result.SuccessCount++;
                         result.ImportedPolicyIds.Add(policy.Id);
@@ -196,26 +199,26 @@ namespace IAMS.Application.Features.Policies.Commands.SyncPoliciesFromMySql
         }
 
         private async Task<Policy> ImportSinglePolicyAsync(
-            ImportPolicyDto dto, string userId, int insuranceCompanyId, CancellationToken cancellationToken)
+            ImportPolicyDto dto, string userId, int insuranceCompanyId, PolicyImportResultDto result, CancellationToken cancellationToken)
         {
             var customer = await GetOrCreateCustomerAsync(dto, userId);
             var policyType = await GetPolicyTypeAsync(dto);
             var currency = await GetCurrencyAsync(dto.CurrencyCode ?? "TRY");
             var vehicle = await GetOrCreateVehicleAsync(dto, customer.Id, userId);
 
-            // Check if this is an endorsement (zeyil). An endorsement must never be imported
-            // without its original policy: an orphan (OriginalPolicyId = null) is invisible
-            // in the customer's policy list yet still counts in balances (#528). Failing the
-            // row here lands it in the sync's error list; the rest of the sync continues.
+            // Check if this is an endorsement (zeyil). A zeyil whose original is not (yet)
+            // in the system is imported anyway with a warning — it shows as its own row in
+            // the UI until the original arrives, at which point it is linked automatically
+            // by IEndorsementLinkService (#528).
             Policy? originalPolicy = null;
             if (dto.InnerCode != "000" && !string.IsNullOrEmpty(dto.PolicyNumber))
             {
                 originalPolicy = await _unitOfWork.Policies.GetByPolicyNumberAsync(dto.PolicyNumber);
                 if (originalPolicy == null)
                 {
-                    throw new InvalidOperationException(
-                        $"Original policy not found for endorsement: PolicyNumber={dto.PolicyNumber}, InnerCode={dto.InnerCode}. " +
-                        $"The original policy (InnerCode=000) must exist in the database or be part of this sync.");
+                    result.Warnings.Add(
+                        $"Zeyil ana poliçesi olmadan içe aktarıldı: Poliçe No={dto.PolicyNumber}, Zeyil No={dto.InnerCode}. " +
+                        "Ana poliçe içe aktarıldığında otomatik olarak bağlanacaktır.");
                 }
             }
 
@@ -261,6 +264,13 @@ namespace IAMS.Application.Features.Policies.Commands.SyncPoliciesFromMySql
             await _unitOfWork.Policies.AddAsync(policy);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
+            // If this row is an original, attach any zeyils that were imported before it
+            if (policy.InnerCode == "000" &&
+                await _endorsementLinkService.LinkOrphanEndorsementsAsync(policy, cancellationToken) > 0)
+            {
+                await _unitOfWork.SaveChangesAsync(cancellationToken);
+            }
+
             // Auto-create payment for traffic and kasko policies (legally required to be fully paid)
             await CreateAutoPaymentIfRequiredAsync(policy, policyType, currency.Id, userId, cancellationToken);
 
@@ -278,7 +288,9 @@ namespace IAMS.Application.Features.Policies.Commands.SyncPoliciesFromMySql
             if (!await _autoPaymentService.ShouldAutoPayAsync(policyType, cancellationToken))
                 return;
 
-            if (policy.PremiumAmount <= 0)
+            // Signed amount: a negative-premium zeyil (iade) gets a matching negative
+            // payment so the traffic chain stays at zero balance (#528).
+            if (policy.PremiumAmount == 0)
                 return;
 
             var payment = new PolicyPayment
@@ -289,7 +301,7 @@ namespace IAMS.Application.Features.Policies.Commands.SyncPoliciesFromMySql
                 PaymentMethod = PaymentMethod.BankTransfer,
                 Status = PaymentStatus.Completed,
                 CurrencyId = currencyId,
-                Notes = _autoPaymentService.AutoPaymentNote,
+                Notes = policy.PremiumAmount < 0 ? _autoPaymentService.AutoRefundNote : _autoPaymentService.AutoPaymentNote,
                 CreatedBy = userId,
                 CreatedOn = DateTime.UtcNow,
                 ModifiedBy = userId,

--- a/src/IAMS.Application/Interfaces/Services/IEndorsementLinkService.cs
+++ b/src/IAMS.Application/Interfaces/Services/IEndorsementLinkService.cs
@@ -1,0 +1,19 @@
+using IAMS.Domain.Entities;
+
+namespace IAMS.Application.Interfaces.Services
+{
+    /// <summary>
+    /// Zeyils (endorsements) may be imported before their original policy exists
+    /// (#528). When the original arrives later, this service attaches the orphans
+    /// so the chain displays and sums as one policy again.
+    /// </summary>
+    public interface IEndorsementLinkService
+    {
+        /// <summary>
+        /// Links previously imported orphan endorsements (same insurance company and
+        /// policy number, no original set) to this original (InnerCode=000) policy.
+        /// The caller's SaveChanges persists the links. Returns the number linked.
+        /// </summary>
+        Task<int> LinkOrphanEndorsementsAsync(Policy originalPolicy, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/IAMS.Application/Interfaces/Services/IImportAutoPaymentService.cs
+++ b/src/IAMS.Application/Interfaces/Services/IImportAutoPaymentService.cs
@@ -14,6 +14,12 @@ namespace IAMS.Application.Interfaces.Services
         string AutoPaymentNote { get; }
 
         /// <summary>
+        /// Note text for the negative payment created for a negative-premium zeyil
+        /// (iade), keeping the traffic-policy chain at zero balance.
+        /// </summary>
+        string AutoRefundNote { get; }
+
+        /// <summary>
         /// True when the policy type is in the traffic family covered by the law:
         /// its code, name, or category contains Trafik/Traffic/Trafic or any Kasko
         /// variant (Kasko, Yarım Kasko, Tam Kasko, ...), in any casing or spelling.

--- a/src/IAMS.Application/Services/PolicyImport/EndorsementLinkService.cs
+++ b/src/IAMS.Application/Services/PolicyImport/EndorsementLinkService.cs
@@ -1,0 +1,52 @@
+using IAMS.Application.Interfaces.Services;
+using IAMS.Domain.Entities;
+using IAMS.Shared.Interfaces.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace IAMS.Application.Services.PolicyImport
+{
+    public class EndorsementLinkService : IEndorsementLinkService
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly ILogger<EndorsementLinkService> _logger;
+
+        public EndorsementLinkService(IUnitOfWork unitOfWork, ILogger<EndorsementLinkService> logger)
+        {
+            _unitOfWork = unitOfWork;
+            _logger = logger;
+        }
+
+        public async Task<int> LinkOrphanEndorsementsAsync(Policy originalPolicy, CancellationToken cancellationToken = default)
+        {
+            if (originalPolicy.InnerCode != "000" || string.IsNullOrEmpty(originalPolicy.PolicyNumber))
+            {
+                return 0;
+            }
+
+            var orphans = await _unitOfWork.Policies.AsQueryable()
+                .Where(p => !p.IsDeleted &&
+                            p.InsuranceCompanyId == originalPolicy.InsuranceCompanyId &&
+                            p.PolicyNumber == originalPolicy.PolicyNumber &&
+                            p.InnerCode != "000" &&
+                            p.OriginalPolicyId == null)
+                .ToListAsync(cancellationToken);
+
+            foreach (var orphan in orphans)
+            {
+                // Navigation property, so linking also works when the original itself is
+                // still unsaved in the current batch (EF resolves the FK on SaveChanges).
+                orphan.OriginalPolicy = originalPolicy;
+            }
+
+            if (orphans.Count > 0)
+            {
+                _logger.LogInformation(
+                    "Linked {Count} orphan zeyil(s) to original policy {PolicyNumber}",
+                    orphans.Count, originalPolicy.PolicyNumber);
+            }
+
+            return orphans.Count;
+        }
+    }
+}

--- a/src/IAMS.Application/Services/PolicyImport/ImportAutoPaymentService.cs
+++ b/src/IAMS.Application/Services/PolicyImport/ImportAutoPaymentService.cs
@@ -30,6 +30,8 @@ namespace IAMS.Application.Services.PolicyImport
 
         public string AutoPaymentNote => "Trafik/Kasko poliçesi - Tam ödeme (Yasal gereklilik)";
 
+        public string AutoRefundNote => "Trafik/Kasko zeyili - Prim iadesi (Yasal gereklilik)";
+
         public bool RequiresFullPaymentByLaw(PolicyType policyType)
         {
             return ContainsMandatoryMarker(policyType.Code) ||

--- a/src/IAMS.Persistence/Repositories/PolicyRepository.cs
+++ b/src/IAMS.Persistence/Repositories/PolicyRepository.cs
@@ -111,7 +111,9 @@ namespace IAMS.Persistence.Repositories
                 .Include(p => p.PolicyType)
                 .Include(p => p.Currency)
                 .Include(p => p.Vehicle)
-                .Where(p => !p.IsDeleted && p.InnerCode == "000"); // Only return main policies, not endorsements
+                // Main policies plus orphan zeyils (imported before their original, #528) —
+                // linked endorsements stay hidden behind their original as before.
+                .Where(p => !p.IsDeleted && (p.InnerCode == "000" || p.OriginalPolicyId == null));
 
             // Apply search filter
             if (!string.IsNullOrWhiteSpace(queryParams.SearchTerm))

--- a/src/IAMS.Shared/DTOs/Policy/PolicyImportResultDto.cs
+++ b/src/IAMS.Shared/DTOs/Policy/PolicyImportResultDto.cs
@@ -9,9 +9,15 @@ namespace IAMS.Shared.DTOs.Policy
         public int SuccessCount { get; set; }
         public int FailureCount { get; set; }
         public List<PolicyImportError> Errors { get; set; } = new();
+
+        /// <summary>
+        /// Non-fatal notices, e.g. a zeyil imported before its original policy (#528).
+        /// </summary>
+        public List<string> Warnings { get; set; } = new();
         public List<int> ImportedPolicyIds { get; set; } = new();
 
         public bool HasErrors => Errors.Any();
+        public bool HasWarnings => Warnings.Any();
     }
 
     public class PolicyImportError

--- a/src/IAMS.Web/Components/Pages/Customers/CustomerDetails.razor
+++ b/src/IAMS.Web/Components/Pages/Customers/CustomerDetails.razor
@@ -313,6 +313,10 @@ else
                                         {
                                             <MudChip Size="Size.Small" Color="Color.Info" T="int">@GetEndorsementCount(context.Id) Zeyil</MudChip>
                                         }
+                                        @if (context.InnerCode != "000")
+                                        {
+                                            <MudChip Size="Size.Small" Color="Color.Warning" T="string" Title="Bu zeyilin ana poliçesi sistemde yok; içe aktarıldığında otomatik bağlanır">Ana poliçe yok</MudChip>
+                                        }
                                     </MudStack>
                                 </MudTd>
                                 <MudTd DataLabel="Poliçe Türü">@context.PolicyType.Name</MudTd>
@@ -641,8 +645,10 @@ else
             {
                 allPolicies = result.Data;
 
-                // Separate main policies from endorsements
-                mainPolicies = allPolicies.Where(p => p.InnerCode == "000").ToList();
+                // Separate main policies from endorsements. Orphan zeyils — imported before
+                // their original policy exists (#528) — are shown as their own rows so the
+                // balance always matches the visible policies.
+                mainPolicies = allPolicies.Where(p => p.InnerCode == "000" || !p.OriginalPolicyId.HasValue).ToList();
 
                 // Group endorsements by their main policy ID
                 endorsementsByPolicy.Clear();

--- a/src/IAMS.Web/Components/Pages/Policies/PolicyImport.razor
+++ b/src/IAMS.Web/Components/Pages/Policies/PolicyImport.razor
@@ -634,10 +634,24 @@
                         }
                     }
 
+                    // Show warnings (e.g. zeyil imported before its original policy)
+                    if (importResult.Warnings.Any())
+                    {
+                        foreach (var warning in importResult.Warnings.Take(5))
+                        {
+                            Snackbar.Add(warning, MudBlazor.Severity.Warning);
+                        }
+                        if (importResult.Warnings.Count > 5)
+                        {
+                            Snackbar.Add($"... ve {importResult.Warnings.Count - 5} uyarı daha", MudBlazor.Severity.Warning);
+                        }
+                    }
+
                     // Navigate to policies list after successful import
                     if (importResult.FailureCount == 0)
                     {
-                        await Task.Delay(1500); // Give user time to see the message
+                        // Give the user time to see the message (longer when warnings are showing)
+                        await Task.Delay(importResult.Warnings.Any() ? 4000 : 1500);
                         Navigation.NavigateTo("/policies");
                     }
                 }


### PR DESCRIPTION
Closes #528. **Reworked after discussion** — the original commit made all paths *reject* orphan zeyils; the agencies want them imported, so this PR implements import-anyway safely:

## What changes

1. **All three import paths accept a zeyil without its original** (Excel, preview/mapping, MySQL sync — the first two used to fail the row). The row imports with a per-row **warning** in the import result ("Zeyil ana poliçesi olmadan içe aktarıldı…"), shown as snackbars in the import UI.
2. **Orphans are visible.** Previously an orphan zeyil appeared *nowhere* (lists only show endorsements grouped under their original) while still counting in the customer's bakiye. Now it shows as its own top-level row — Cari Kart Poliçeler tab and the main policy list — with an **"Ana poliçe yok"** warning chip.
3. **Self-healing links.** When the original (`InnerCode=000`) is imported later, the new `EndorsementLinkService` attaches every orphan zeyil with the same insurer + policy number, restoring the normal nested display. Import order no longer matters.
4. **Auto-payment is now signed** (when the per-agency rule is ON): a negative-premium zeyil (iade) creates a matching **negative payment** — note "Trafik/Kasko zeyili - Prim iadesi (Yasal gereklilik)" — so the traffic chain stays at exactly zero balance. Previously refunds were skipped, leaving a permanent phantom credit. Agencies that don't want auto-payments at all already have the `AutoPayMandatoryPolicies` switch (Ayarlar > Genel) — turned off, zeyils and originals alike get no synthetic payments.
5. MySQL sync keeps the **originals-first ordering** so same-sync originals are found immediately.

## Assumption (stated in review discussion)
Zeyil premiums are treated as **deltas** (ek prim / iade amounts), matching how balances already sum policy rows everywhere in the system. If any insurer exports restated full premiums on zeyil rows, that's a data problem independent of this PR.

Build clean; 195 unit + 35 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)