### PR TITLE
Repo hygiene: CI on master, AutoMapper 13, branch cleanup (#513 partial)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,12 +3,14 @@ name: CI/CD Pipeline
 on:
   push:
     branches:
+      - master   # default branch — CI was silently skipped while this listed only 'main' (#513)
       - main
       - develop
       - 'release/**'
       - 'hotfix/**'
   pull_request:
     branches:
+      - master
       - main
       - develop
   workflow_dispatch:  # Allow manual trigger

--- a/src/IAMS.Application/IAMS.Application.csproj
+++ b/src/IAMS.Application/IAMS.Application.csproj
@@ -7,8 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="ClosedXML" Version="0.102.3" />
     <PackageReference Include="FluentValidation" Version="11.8.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />

--- a/src/IAMS.Web/IAMS.Web.csproj
+++ b/src/IAMS.Web/IAMS.Web.csproj
@@ -26,8 +26,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />

--- a/tests/IAMS.UnitTests/IAMS.UnitTests.csproj
+++ b/tests/IAMS.UnitTests/IAMS.UnitTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.5" />


### PR DESCRIPTION
Part of #513 — the items that could be done safely today:

## CI was not running at all
The workflow triggered on `main`/`develop`, but the default branch is **`master`** — so no build, tests, CodeQL, or secret scan has run for any master push or PR. `master` is now in both `push` and `pull_request` triggers. **After merging this, PRs will finally show checks.**

## AutoMapper
`12.0.1 → 13.0.1` (still MIT) and the deprecated `AutoMapper.Extensions.Microsoft.DependencyInjection` package removed (merged into the main package in v13). ⚠️ The high-severity advisory GHSA-rvv3-g6hj-g44x (DoS via uncontrolled recursion) is **only patched in 15.1.1+**, and v15 is under Lucky Penny's commercial licensing — whether to buy/qualify for that is a business decision, left on #513. Practical exposure is limited (mappings run over app-controlled DTOs, not raw user payloads).

## Branch cleanup (already executed on origin)
79 remote branches → **5**: deleted 70 that were merged via git history or a merged PR; kept `master`, `main`, the open PR branch, and `claude/all-today-fixes` + `claude/add-missing-services-…` which contain unmerged work (decide their fate manually).

## Still open on #513
- Build warnings census (full rebuild): **156× MUD0002** (MudBlazor attribute misuse), ~250 nullable-reference warnings (CS86xx), 36 CS1998, 22 CS0168, 20 CS0105 — deserves its own sweep.
- Master DB schema managed by ad-hoc SQL scripts + no EF migrations anywhere (fresh DBs can't be built from the repo — the local-db work in #526 papered over this with `EnsureCreated`). Adopting EF migrations is a real project.

195 unit + 35 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)